### PR TITLE
Font issue fix + fix memory leak

### DIFF
--- a/lib/nxui/include/nxui/core/GpuDevice.hpp
+++ b/lib/nxui/include/nxui/core/GpuDevice.hpp
@@ -56,7 +56,7 @@ public:
     static constexpr int FB_HEIGHT = 720;
     static constexpr int NUM_FB    = 2;
 
-    static constexpr int MAX_TEXTURES   = 1024;
+    static constexpr int MAX_TEXTURES   = 2048;
     static constexpr int MAX_SAMPLERS   = 16;
     static constexpr int MAX_VERTICES   = 65536;
     static constexpr int VTX_BUF_SIZE   = MAX_VERTICES * 32;
@@ -112,7 +112,7 @@ public:
     dk::UniqueMemBlock allocImageMemory(uint32_t size);
     void freeImageMemory(uint32_t size);
 
-    static constexpr uint64_t kDefaultImageBudget = 16u * 1024u * 1024u;
+    static constexpr uint64_t kDefaultImageBudget = 64u * 1024u * 1024u;
     uint64_t imageMemoryUsed() const { return m_imageMemUsed; }
 
     bool uploadTexture(dk::Image& dst, const void* pixels, uint32_t size, uint32_t width, uint32_t height);

--- a/lib/nxui/include/nxui/core/GpuDevice.hpp
+++ b/lib/nxui/include/nxui/core/GpuDevice.hpp
@@ -112,7 +112,7 @@ public:
     dk::UniqueMemBlock allocImageMemory(uint32_t size);
     void freeImageMemory(uint32_t size);
 
-    static constexpr uint64_t kDefaultImageBudget = 64u * 1024u * 1024u;
+    static constexpr uint64_t kDefaultImageBudget = 32u * 1024u * 1024u;
     uint64_t imageMemoryUsed() const { return m_imageMemUsed; }
 
     bool uploadTexture(dk::Image& dst, const void* pixels, uint32_t size, uint32_t width, uint32_t height);

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -329,8 +329,8 @@ void WiiUMenuApp::buildGrid() {
 
     SidebarManager::Actions sidebarActions;
 #ifndef SWITCHU_HOMEBREW
-    sidebarActions.onAlbum       = [this]() { m_launcher.launchAlbum(); };
-    sidebarActions.onMiiEditor   = [this]() { m_launcher.launchMiiEditor(); };
+    sidebarActions.onAlbum       = [this]() { m_launcher.launchAlbum(); svcSleepThread(300000000ull); svcExitProcess(); };
+    sidebarActions.onMiiEditor   = [this]() { m_launcher.launchMiiEditor(); svcSleepThread(300000000ull); svcExitProcess(); };
     sidebarActions.onControllers = [this]() { m_launcher.launchControllerPairing(); };
 #else
     sidebarActions.onAlbum       = [this]() { m_audio.playSfx(Sfx::Activate); };

--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -17,7 +17,7 @@
 namespace {
 
 constexpr int kIconUploadSize   = 256;
-constexpr int kMaxIconTextures  = 60;
+constexpr int kMaxIconTextures  = 150;
 
 void decodeIcons(std::vector<PendingApp>& apps) {
     DebugLog::log("[loader] decoding %d icons on worker threads...", (int)apps.size());
@@ -74,10 +74,8 @@ void decodeIcons(std::vector<PendingApp>& apps) {
             }
         }
     };
-    constexpr int NUM_WORKERS = 3;
-    std::thread workers[NUM_WORKERS];
-    for (int t = 0; t < NUM_WORKERS; ++t) workers[t] = std::thread(workerFn);
-    for (int t = 0; t < NUM_WORKERS; ++t) workers[t].join();
+    // plugging your memory leak <3 ~Arch
+    workerFn();
     DebugLog::log("[loader] decode done");
 }
 

--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -17,7 +17,7 @@
 namespace {
 
 constexpr int kIconUploadSize   = 256;
-constexpr int kMaxIconTextures  = 150;
+constexpr int kMaxIconTextures  = 100;
 
 void decodeIcons(std::vector<PendingApp>& apps) {
     DebugLog::log("[loader] decoding %d icons on worker threads...", (int)apps.size());

--- a/toolchain/devkitA64.lua
+++ b/toolchain/devkitA64.lua
@@ -45,5 +45,9 @@ toolchain("devkita64")
         -- ── libnx (always needed for switch.specs / <switch.h>) ──
         toolchain:add("includedirs", path.join(LIBNX, "include"))
         toolchain:add("linkdirs", path.join(LIBNX, "lib"))
+		
+		local PORTLIBS = path.join(DEVKITPRO, "portlibs", "switch")
+        toolchain:add("includedirs", path.join(PORTLIBS, "include"))
+        toolchain:add("linkdirs", path.join(PORTLIBS, "lib"))
     end)
 toolchain_end()


### PR DESCRIPTION
as title mentioned. I adjusted the gpu memory to allow the font to correctly show for others as well as increase the maximum icons to show but a little bit but not too much. Also fixed a memory leak you had with the thread workers in the source code that idk if it was present in your release build. Also added a thread delay and svc exit on the applets as they would crash with the extra memory on icons/font.