### PR TITLE
Fix missing icons on page 2 by improving icon streaming and cache fal…

### DIFF
--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -101,26 +101,43 @@ void AppListLoader::fetchApps() {
 
         uint32_t vf = views[i].flags;
 
+        std::string cachedName;
+        bool cacheHasUsableIcon = false;
         NxTitleCacheApplicationMetadata* meta = nxtcGetApplicationMetadataEntryById(tid);
         if (meta) {
-            PendingApp a;
-            a.id      = tidBuf;
-            a.title   = meta->name ? meta->name : "";
-            a.titleId = tid;
-            a.viewFlags = vf;
+            cachedName = meta->name ? meta->name : "";
             if (meta->icon_data && meta->icon_size > 0) {
+                cacheHasUsableIcon = true;
+                PendingApp a;
+                a.id      = tidBuf;
+                a.title   = cachedName;
+                a.titleId = tid;
+                a.viewFlags = vf;
                 auto* ptr = static_cast<const uint8_t*>(meta->icon_data);
                 a.iconData.assign(ptr, ptr + meta->icon_size);
+                m_pending.push_back(std::move(a));
             }
-            m_pending.push_back(std::move(a));
             nxtcFreeApplicationMetadata(&meta);
-            continue;
+            if (cacheHasUsableIcon)
+                continue;
+
+            DebugLog::log("[loader] cache entry missing icon for %016lX, refreshing from NS", (unsigned long)tid);
         }
 
         size_t controlSize = 0;
         Result rc = nsGetApplicationControlData(NsApplicationControlSource_Storage, tid,
                                                 &controlData, sizeof(controlData), &controlSize);
-        if (R_FAILED(rc)) continue;
+        if (R_FAILED(rc)) {
+            if (!cachedName.empty()) {
+                PendingApp a;
+                a.id      = tidBuf;
+                a.title   = cachedName;
+                a.titleId = tid;
+                a.viewFlags = vf;
+                m_pending.push_back(std::move(a));
+            }
+            continue;
+        }
 
         NacpLanguageEntry* langEntry = nullptr;
         rc = nacpGetLanguageEntry(&controlData.nacp, &langEntry);

--- a/projects/menu/src/launcher/IconStreamer.cpp
+++ b/projects/menu/src/launcher/IconStreamer.cpp
@@ -107,6 +107,8 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
     int endPage   = std::min(totalPages - 1, currentPage + kPageMargin);
     int startApp  = startPage * iconsPerPage;
     int endApp    = std::min(totalApps, (endPage + 1) * iconsPerPage);
+    int curStart  = currentPage * iconsPerPage;
+    int curEnd    = std::min(totalApps, curStart + iconsPerPage);
 
     // 1. Evict textures outside the new visible range.
     for (int i = 0; i < (int)m_pool.size(); ++i) {
@@ -121,11 +123,21 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
     }
 
     // 2. Collect apps that need loading.
-    std::vector<int> toLoad;
+    // Prioritize current-page icons first so page switches never show blanks
+    // when we are under memory pressure.
+    std::vector<int> currentToLoad;
+    std::vector<int> neighborToLoad;
     for (int i = startApp; i < endApp; ++i) {
-        if (m_appToSlot[i] < 0 && !m_compressed[i].empty())
-            toLoad.push_back(i);
+        if (m_appToSlot[i] < 0 && !m_compressed[i].empty()) {
+            if (i >= curStart && i < curEnd) currentToLoad.push_back(i);
+            else neighborToLoad.push_back(i);
+        }
     }
+
+    std::vector<int> toLoad;
+    toLoad.reserve(currentToLoad.size() + neighborToLoad.size());
+    toLoad.insert(toLoad.end(), currentToLoad.begin(), currentToLoad.end());
+    toLoad.insert(toLoad.end(), neighborToLoad.begin(), neighborToLoad.end());
 
     if (toLoad.empty()) return;
 
@@ -173,6 +185,7 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
         m_pool.reserve(m_pool.size() + newSlots);
     }
 
+    std::vector<int> failedCurrent;
     for (auto& d : decoded) {
         if (!d.rgba) continue;
 
@@ -192,10 +205,68 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
             m_appToSlot[d.appIndex] = poolIdx;
             if (d.appIndex < (int)allIcons.size())
                 allIcons[d.appIndex]->setTexture(&slot.texture);
+        } else {
+            m_appToSlot[d.appIndex] = -1;
+            slot.appIndex = -1;
+            m_freeSlots.push_back(poolIdx);
+            if (d.appIndex >= curStart && d.appIndex < curEnd)
+                failedCurrent.push_back(d.appIndex);
         }
 
         if (d.scaledWithMalloc) std::free(d.rgba);
         else stbi_image_free(d.rgba);
+    }
+
+    // 5. If current page still has missing icons, drop preloaded neighbors and
+    //    retry only the missing current-page entries.
+    if (!failedCurrent.empty()) {
+        DebugLog::log("[streamer] page %d: retrying %d current icons after load failures",
+                      currentPage, (int)failedCurrent.size());
+
+        for (int i = 0; i < (int)m_pool.size(); ++i) {
+            int app = m_pool[i].appIndex;
+            if (app >= 0 && (app < curStart || app >= curEnd)) {
+                if (app < (int)allIcons.size())
+                    allIcons[app]->setTexture(nullptr);
+                m_appToSlot[app] = -1;
+                m_pool[i].appIndex = -1;
+                m_freeSlots.push_back(i);
+            }
+        }
+
+        for (int appIndex : failedCurrent) {
+            if (m_appToSlot[appIndex] >= 0 || m_compressed[appIndex].empty())
+                continue;
+
+            auto d = decodeAndScale(appIndex);
+            if (!d.rgba) continue;
+
+            int poolIdx;
+            if (!m_freeSlots.empty()) {
+                poolIdx = m_freeSlots.back();
+                m_freeSlots.pop_back();
+            } else {
+                poolIdx = (int)m_pool.size();
+                m_pool.emplace_back();
+            }
+
+            auto& slot = m_pool[poolIdx];
+            if (slot.texture.loadFromPixels(gpu, ren, d.rgba, d.w, d.h)) {
+                slot.appIndex = appIndex;
+                m_appToSlot[appIndex] = poolIdx;
+                if (appIndex < (int)allIcons.size())
+                    allIcons[appIndex]->setTexture(&slot.texture);
+            } else {
+                slot.appIndex = -1;
+                m_appToSlot[appIndex] = -1;
+                m_freeSlots.push_back(poolIdx);
+                DebugLog::log("[streamer] page %d: icon %d still failed after retry",
+                              currentPage, appIndex);
+            }
+
+            if (d.scaledWithMalloc) std::free(d.rgba);
+            else stbi_image_free(d.rgba);
+        }
     }
 }
 

--- a/projects/menu/src/launcher/IconStreamer.hpp
+++ b/projects/menu/src/launcher/IconStreamer.hpp
@@ -66,7 +66,9 @@ private:
 
     int m_lastPage = -1;
 
-    // How many pages around the current one to keep loaded.
-    static constexpr int kPageMargin = 1;
+    // Keep only the visible page loaded. This is more aggressive than
+    // prefetching neighbors, but avoids starving the current page when the
+    // GPU/image budget is tight.
+    static constexpr int kPageMargin = 0;
     static constexpr int kIconSize   = 256;
 };


### PR DESCRIPTION
## Summary
Fixes an issue where page 2 could show missing/blank game icons while other pages loaded correctly.

## Changes
- Icon streaming:
  - prioritize loading current page icons first
  - retry failed current-page icon uploads
  - reduce prefetch pressure (current page only)

- App list loading:
  - avoid trusting stale `libnxtc` cache entries when icon bytes are missing
  - fallback to `nsGetApplicationControlData` to refresh icon data
  - preserve title entries if NS refresh fails

## Files changed
- projects/menu/src/launcher/IconStreamer.hpp
- projects/menu/src/launcher/IconStreamer.cpp
- projects/menu/src/launcher/AppListLoader.cpp

## Validation
- Build succeeded with `xmake -v` (devkitA64)
- Packaged with `xmake install -o build/sd_out`
- Tested on device with updated files and cleared `sdmc:/config/SwitchU/applist.bin`