### PR TITLE
fix icon streamer

### DIFF
--- a/projects/menu/src/launcher/IconStreamer.cpp
+++ b/projects/menu/src/launcher/IconStreamer.cpp
@@ -161,7 +161,9 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
 
     // Pre-reserve pool capacity so emplace_back() never reallocates.
     // Reallocation would invalidate texture pointers already handed out
-    // to GlossyIcon widgets earlier in this loop.
+    // to GlossyIcon widgets earlier in this loop — but also pointers
+    // from *previous* onPageChanged() calls for icons that survived
+    // eviction.  After a reallocation we must re-wire every loaded icon.
     {
         int newSlots = 0;
         int freeAvail = (int)m_freeSlots.size();
@@ -170,7 +172,19 @@ void IconStreamer::onPageChanged(int currentPage, int iconsPerPage,
             if (freeAvail > 0) --freeAvail;
             else ++newSlots;
         }
-        m_pool.reserve(m_pool.size() + newSlots);
+        if (newSlots > 0) {
+            auto* oldData = m_pool.data();
+            m_pool.reserve(m_pool.size() + newSlots);
+            if (m_pool.data() != oldData) {
+                // Pool was moved to a new allocation – re-wire every
+                // surviving icon so their Texture* pointers stay valid.
+                for (int i = 0; i < (int)m_pool.size(); ++i) {
+                    int app = m_pool[i].appIndex;
+                    if (app >= 0 && app < (int)allIcons.size())
+                        allIcons[app]->setTexture(&m_pool[i].texture);
+                }
+            }
+        }
     }
 
     for (auto& d : decoded) {


### PR DESCRIPTION
What happens:
- GlossyIcon stores a raw nxui::Texture* pointing directly into m_pool (a std::vector<TexSlot>)
- When navigating from page 0 to page 1, onPageChanged(1) needs to load page 2 icons (prefetch via kPageMargin=1). No free slots exist, so m_pool.reserve() is called to grow the pool
- reserve() reallocates the vector, moving all TexSlot objects to new memory. Every Texture* pointer previously given to page 0 and page 1 icons now points to freed memory
- Page 1 (the current page) renders blank because m_tex is dangling
- The icons are still marked as "loaded" in m_appToSlot, so they never get re-loaded — until the user navigates far enough away to evict them, then comes back

The fix (lines 175-187): 
After reserve(), compare m_pool.data() before and after. If the pool was relocated, iterate all pool slots and re-wire the Texture* pointer on every surviving GlossyIcon. This is O(pool_size) and only runs when an actual reallocation occurs, so there's negligible performance impact.
