### PR TITLE
feat: folder placement past page 1, extra folder styles, and Show cover

### DIFF
--- a/projects/menu/src/core/Config.cpp
+++ b/projects/menu/src/core/Config.cpp
@@ -65,6 +65,7 @@ bool AppConfig::load() {
     readJsonOpt(j, "steamGridDbEnabled", steamGridDbEnabled);
     readJsonOpt(j, "steamGridDbApiKey", steamGridDbApiKey);
     readJsonOpt(j, "themePreset", themePreset);
+    readJsonOpt(j, "folderStyle", folderStyle);
 
     if (musicVolume < 0.f) musicVolume = 0.f;
     if (musicVolume > 1.f) musicVolume = 1.f;
@@ -79,6 +80,7 @@ bool AppConfig::load() {
     if (!defaultProfileEnabled) defaultProfileUid.clear();
     accessibilitySpeechRate = std::clamp(accessibilitySpeechRate, 120, 320);
     if (themePreset.empty()) themePreset = "Default Light";
+    folderStyle = std::clamp(folderStyle, 0, 1);
 
     return true;
 }
@@ -111,6 +113,7 @@ bool AppConfig::save() const {
     j["steamGridDbEnabled"] = steamGridDbEnabled;
     j["steamGridDbApiKey"] = steamGridDbApiKey;
     j["themePreset"] = themePreset;
+    j["folderStyle"] = std::clamp(folderStyle, 0, 1);
 
     std::ofstream f(kConfigPath, std::ios::trunc);
     if (!f.is_open()) return false;

--- a/projects/menu/src/core/Config.cpp
+++ b/projects/menu/src/core/Config.cpp
@@ -1,4 +1,5 @@
 #include "Config.hpp"
+#include "FolderStore.hpp"
 #include <fstream>
 #include <algorithm>
 #include <filesystem>
@@ -66,6 +67,8 @@ bool AppConfig::load() {
     readJsonOpt(j, "steamGridDbApiKey", steamGridDbApiKey);
     readJsonOpt(j, "themePreset", themePreset);
     readJsonOpt(j, "folderStyle", folderStyle);
+    const bool hasShowCoverKey = j.find("folderShowCover") != j.end();
+    readJsonOpt(j, "folderShowCover", folderShowCover);
 
     if (musicVolume < 0.f) musicVolume = 0.f;
     if (musicVolume > 1.f) musicVolume = 1.f;
@@ -80,7 +83,28 @@ bool AppConfig::load() {
     if (!defaultProfileEnabled) defaultProfileUid.clear();
     accessibilitySpeechRate = std::clamp(accessibilitySpeechRate, 120, 320);
     if (themePreset.empty()) themePreset = "Default Light";
-    folderStyle = std::clamp(folderStyle, 0, 1);
+    if (!hasShowCoverKey) {
+        // Local 9-style table used while vetting Cover/Plate as separate styles.
+        switch (folderStyle) {
+            case 0: // Classic
+            case 1: // Simple
+                break;
+            case 2: // Cover → Simple + cover
+                folderStyle = switchu::folders::kFolderStyleSimple;
+                folderShowCover = true;
+                break;
+            case 3: folderStyle = switchu::folders::kFolderStyleMinimal; break;
+            case 4: folderStyle = switchu::folders::kFolderStyleTab; break;
+            case 5: folderStyle = switchu::folders::kFolderStyleRing; break;
+            case 6: folderStyle = switchu::folders::kFolderStyleManila; break;
+            case 7: folderStyle = switchu::folders::kFolderStyleClassic; break; // Plate
+            case 8: folderStyle = switchu::folders::kFolderStyleLabel; break;
+            default:
+                folderStyle = switchu::folders::kDefaultFolderStyle;
+                break;
+        }
+    }
+    folderStyle = std::clamp(folderStyle, 0, switchu::folders::kFolderStyleCount - 1);
 
     return true;
 }
@@ -113,7 +137,8 @@ bool AppConfig::save() const {
     j["steamGridDbEnabled"] = steamGridDbEnabled;
     j["steamGridDbApiKey"] = steamGridDbApiKey;
     j["themePreset"] = themePreset;
-    j["folderStyle"] = std::clamp(folderStyle, 0, 1);
+    j["folderStyle"] = std::clamp(folderStyle, 0, switchu::folders::kFolderStyleCount - 1);
+    j["folderShowCover"] = folderShowCover;
 
     std::ofstream f(kConfigPath, std::ios::trunc);
     if (!f.is_open()) return false;

--- a/projects/menu/src/core/Config.hpp
+++ b/projects/menu/src/core/Config.hpp
@@ -25,6 +25,8 @@ struct AppConfig {
     std::string steamGridDbApiKey;
 
     std::string themePreset = "Default Light";
+    // 0 = Classic, 1 = Glass. Applies to every folder tile.
+    int folderStyle = 1;
 
     bool load();
 

--- a/projects/menu/src/core/Config.hpp
+++ b/projects/menu/src/core/Config.hpp
@@ -25,8 +25,10 @@ struct AppConfig {
     std::string steamGridDbApiKey;
 
     std::string themePreset = "Default Light";
-    // 0 = Classic, 1 = Simple. Applies to every folder tile.
-    int folderStyle = 1;
+    // See switchu::folders::kFolderStyle*. Applies to every folder tile.
+    int folderStyle = 0;
+    // First-game icon overlay. Ignored by Classic (the mosaic is the cover).
+    bool folderShowCover = false;
 
     bool load();
 

--- a/projects/menu/src/core/Config.hpp
+++ b/projects/menu/src/core/Config.hpp
@@ -25,7 +25,7 @@ struct AppConfig {
     std::string steamGridDbApiKey;
 
     std::string themePreset = "Default Light";
-    // 0 = Classic, 1 = Glass. Applies to every folder tile.
+    // 0 = Classic, 1 = Simple. Applies to every folder tile.
     int folderStyle = 1;
 
     bool load();

--- a/projects/menu/src/core/FolderStore.cpp
+++ b/projects/menu/src/core/FolderStore.cpp
@@ -106,10 +106,13 @@ bool FolderStore::load() {
             folder.colorIndex = std::clamp(
                 item.value("color", static_cast<int>(folder.id % 8u)), 0, 7);
             folder.sizeIndex = std::clamp(item.value("size", 1), 0, 2);
+            folder.styleIndex = std::clamp(
+                item.value("style", kDefaultFolderStyle), 0, kFolderStyleCount - 1);
             folder.pageCount = std::clamp(item.value("pages", 1), 1, kMaxFolderPages);
         } catch (...) {
             folder.colorIndex = static_cast<int>(folder.id % 8u);
             folder.sizeIndex = 1;
+            folder.styleIndex = kDefaultFolderStyle;
             folder.pageCount = 1;
         }
         usedIds.insert(folder.id);
@@ -146,6 +149,7 @@ bool FolderStore::save() const {
         item["name"] = folder.name;
         item["color"] = folder.colorIndex;
         item["size"] = folder.sizeIndex;
+        item["style"] = folder.styleIndex;
         item["pages"] = folder.pageCount;
         item["titles"] = nlohmann::json::array();
         for (std::uint64_t titleId : folder.titleIds)
@@ -236,6 +240,7 @@ std::uint32_t FolderStore::create(std::string name) {
     folder.name = std::move(name);
     folder.colorIndex = static_cast<int>(id % 8u);
     folder.sizeIndex = 1;
+    folder.styleIndex = kDefaultFolderStyle;
     m_folders.push_back(std::move(folder));
     return id;
 }
@@ -351,6 +356,14 @@ bool FolderStore::setSizeIndex(std::uint32_t folderId, int sizeIndex) {
     if (!folder)
         return false;
     folder->sizeIndex = std::clamp(sizeIndex, 0, 2);
+    return true;
+}
+
+bool FolderStore::setStyleIndex(std::uint32_t folderId, int styleIndex) {
+    Folder* folder = find(folderId);
+    if (!folder)
+        return false;
+    folder->styleIndex = std::clamp(styleIndex, 0, kFolderStyleCount - 1);
     return true;
 }
 

--- a/projects/menu/src/core/FolderStore.cpp
+++ b/projects/menu/src/core/FolderStore.cpp
@@ -106,13 +106,10 @@ bool FolderStore::load() {
             folder.colorIndex = std::clamp(
                 item.value("color", static_cast<int>(folder.id % 8u)), 0, 7);
             folder.sizeIndex = std::clamp(item.value("size", 1), 0, 2);
-            folder.styleIndex = std::clamp(
-                item.value("style", kDefaultFolderStyle), 0, kFolderStyleCount - 1);
             folder.pageCount = std::clamp(item.value("pages", 1), 1, kMaxFolderPages);
         } catch (...) {
             folder.colorIndex = static_cast<int>(folder.id % 8u);
             folder.sizeIndex = 1;
-            folder.styleIndex = kDefaultFolderStyle;
             folder.pageCount = 1;
         }
         usedIds.insert(folder.id);
@@ -149,7 +146,6 @@ bool FolderStore::save() const {
         item["name"] = folder.name;
         item["color"] = folder.colorIndex;
         item["size"] = folder.sizeIndex;
-        item["style"] = folder.styleIndex;
         item["pages"] = folder.pageCount;
         item["titles"] = nlohmann::json::array();
         for (std::uint64_t titleId : folder.titleIds)
@@ -240,7 +236,6 @@ std::uint32_t FolderStore::create(std::string name) {
     folder.name = std::move(name);
     folder.colorIndex = static_cast<int>(id % 8u);
     folder.sizeIndex = 1;
-    folder.styleIndex = kDefaultFolderStyle;
     m_folders.push_back(std::move(folder));
     return id;
 }
@@ -356,14 +351,6 @@ bool FolderStore::setSizeIndex(std::uint32_t folderId, int sizeIndex) {
     if (!folder)
         return false;
     folder->sizeIndex = std::clamp(sizeIndex, 0, 2);
-    return true;
-}
-
-bool FolderStore::setStyleIndex(std::uint32_t folderId, int styleIndex) {
-    Folder* folder = find(folderId);
-    if (!folder)
-        return false;
-    folder->styleIndex = std::clamp(styleIndex, 0, kFolderStyleCount - 1);
     return true;
 }
 

--- a/projects/menu/src/core/FolderStore.cpp
+++ b/projects/menu/src/core/FolderStore.cpp
@@ -280,11 +280,20 @@ bool FolderStore::addTitle(std::uint32_t folderId, std::uint64_t titleId) {
     const std::uint32_t previous = folderForTitle(titleId);
     if (previous == folderId)
         return true;
+    const auto hole = std::find(folder->titleIds.begin(), folder->titleIds.end(), 0ULL);
+    if (hole == folder->titleIds.end() &&
+        folder->titleIds.size() >= maxFolderSlots(folder->sizeIndex))
+        return false;
     if (previous != 0)
         removeTitle(previous, titleId);
-    auto hole = std::find(folder->titleIds.begin(), folder->titleIds.end(), 0ULL);
-    if (hole != folder->titleIds.end())
-        *hole = titleId;
+    // Removing from another folder does not invalidate this folder, but look
+    // it up again so this remains safe if the storage implementation changes.
+    folder = find(folderId);
+    if (!folder)
+        return false;
+    auto targetHole = std::find(folder->titleIds.begin(), folder->titleIds.end(), 0ULL);
+    if (targetHole != folder->titleIds.end())
+        *targetHole = titleId;
     else
         folder->titleIds.push_back(titleId);
     return true;
@@ -299,6 +308,9 @@ bool FolderStore::placeTitle(std::uint32_t folderId, std::uint64_t titleId,
         return false;
 
     const std::uint32_t previous = folderForTitle(titleId);
+    const std::size_t maximum = maxFolderSlots(target->sizeIndex);
+    if (index >= maximum)
+        return false;
 
     // Reordering inside the same folder must swap (or relocate into a hole),
     // matching the HOME menu. Zeroing the source and inserting at the target
@@ -318,6 +330,14 @@ bool FolderStore::placeTitle(std::uint32_t folderId, std::uint64_t titleId,
         return true;
     }
 
+    const auto existingHole = std::find(target->titleIds.begin(),
+                                        target->titleIds.end(), 0ULL);
+    const bool targetOccupied = index < target->titleIds.size() &&
+                                target->titleIds[index] != 0;
+    if (targetOccupied && existingHole == target->titleIds.end() &&
+        target->titleIds.size() >= maximum)
+        return false;
+
     if (previous != 0) {
         Folder* source = find(previous);
         if (source) {
@@ -335,11 +355,25 @@ bool FolderStore::placeTitle(std::uint32_t folderId, std::uint64_t titleId,
 
     if (index >= target->titleIds.size())
         target->titleIds.resize(index + 1, 0);
-    if (target->titleIds[index] == 0)
+    if (target->titleIds[index] == 0) {
         target->titleIds[index] = titleId;
-    else
+    } else if (existingHole == target->titleIds.end()) {
         target->titleIds.insert(target->titleIds.begin() + static_cast<std::ptrdiff_t>(index),
                                 titleId);
+    } else {
+        const std::size_t holeIndex = static_cast<std::size_t>(
+            existingHole - target->titleIds.begin());
+        if (holeIndex > index) {
+            std::move_backward(target->titleIds.begin() + static_cast<std::ptrdiff_t>(index),
+                               target->titleIds.begin() + static_cast<std::ptrdiff_t>(holeIndex),
+                               target->titleIds.begin() + static_cast<std::ptrdiff_t>(holeIndex + 1));
+        } else {
+            std::move(target->titleIds.begin() + static_cast<std::ptrdiff_t>(holeIndex + 1),
+                      target->titleIds.begin() + static_cast<std::ptrdiff_t>(index + 1),
+                      target->titleIds.begin() + static_cast<std::ptrdiff_t>(holeIndex));
+        }
+        target->titleIds[index] = titleId;
+    }
     return true;
 }
 
@@ -369,7 +403,10 @@ bool FolderStore::setSizeIndex(std::uint32_t folderId, int sizeIndex) {
     Folder* folder = find(folderId);
     if (!folder)
         return false;
-    folder->sizeIndex = std::clamp(sizeIndex, 0, 2);
+    const int clamped = std::clamp(sizeIndex, 0, 2);
+    if (folder->titleIds.size() > maxFolderSlots(clamped))
+        return false;
+    folder->sizeIndex = clamped;
     return true;
 }
 

--- a/projects/menu/src/core/FolderStore.hpp
+++ b/projects/menu/src/core/FolderStore.hpp
@@ -18,7 +18,6 @@ struct Folder {
     std::vector<std::uint64_t> titleIds;
     int colorIndex = 0;
     int sizeIndex = 1;
-    int styleIndex = kDefaultFolderStyle;
     int pageCount = 1;
 
     std::size_t titleCount() const;
@@ -46,7 +45,6 @@ public:
     bool removeTitle(std::uint32_t folderId, std::uint64_t titleId);
     bool setColorIndex(std::uint32_t folderId, int colorIndex);
     bool setSizeIndex(std::uint32_t folderId, int sizeIndex);
-    bool setStyleIndex(std::uint32_t folderId, int styleIndex);
     bool setPageCount(std::uint32_t folderId, int pages);
     std::uint32_t folderForTitle(std::uint64_t titleId) const;
 

--- a/projects/menu/src/core/FolderStore.hpp
+++ b/projects/menu/src/core/FolderStore.hpp
@@ -7,12 +7,18 @@
 
 namespace switchu::folders {
 
+inline constexpr int kFolderStyleClassic = 0;
+inline constexpr int kFolderStyleGlass = 1;
+inline constexpr int kFolderStyleCount = 2;
+inline constexpr int kDefaultFolderStyle = kFolderStyleGlass;
+
 struct Folder {
     std::uint32_t id = 0;
     std::string name;
     std::vector<std::uint64_t> titleIds;
     int colorIndex = 0;
     int sizeIndex = 1;
+    int styleIndex = kDefaultFolderStyle;
     int pageCount = 1;
 
     std::size_t titleCount() const;
@@ -40,6 +46,7 @@ public:
     bool removeTitle(std::uint32_t folderId, std::uint64_t titleId);
     bool setColorIndex(std::uint32_t folderId, int colorIndex);
     bool setSizeIndex(std::uint32_t folderId, int sizeIndex);
+    bool setStyleIndex(std::uint32_t folderId, int styleIndex);
     bool setPageCount(std::uint32_t folderId, int pages);
     std::uint32_t folderForTitle(std::uint64_t titleId) const;
 

--- a/projects/menu/src/core/FolderStore.hpp
+++ b/projects/menu/src/core/FolderStore.hpp
@@ -9,8 +9,21 @@ namespace switchu::folders {
 
 inline constexpr int kFolderStyleClassic = 0;
 inline constexpr int kFolderStyleSimple = 1;
-inline constexpr int kFolderStyleCount = 2;
-inline constexpr int kDefaultFolderStyle = kFolderStyleSimple;
+inline constexpr int kFolderStyleMinimal = 2;
+inline constexpr int kFolderStyleTab = 3;
+inline constexpr int kFolderStyleRing = 4;
+inline constexpr int kFolderStyleManila = 5;
+inline constexpr int kFolderStyleLabel = 6;
+inline constexpr int kFolderStyleCount = 7;
+inline constexpr int kDefaultFolderStyle = kFolderStyleClassic;
+
+inline bool folderStyleSupportsCover(int styleIndex) {
+    return styleIndex != kFolderStyleClassic;
+}
+
+inline bool folderShouldShowCover(int styleIndex, bool showCover) {
+    return showCover && folderStyleSupportsCover(styleIndex);
+}
 
 struct Folder {
     std::uint32_t id = 0;
@@ -22,6 +35,10 @@ struct Folder {
 
     std::size_t titleCount() const;
 };
+
+inline std::uint64_t firstCoverTitleId(const Folder& folder) {
+    return folder.titleIds.empty() ? 0 : folder.titleIds.front();
+}
 
 inline constexpr int kMaxFolderPages = 8;
 

--- a/projects/menu/src/core/FolderStore.hpp
+++ b/projects/menu/src/core/FolderStore.hpp
@@ -8,9 +8,9 @@
 namespace switchu::folders {
 
 inline constexpr int kFolderStyleClassic = 0;
-inline constexpr int kFolderStyleGlass = 1;
+inline constexpr int kFolderStyleSimple = 1;
 inline constexpr int kFolderStyleCount = 2;
-inline constexpr int kDefaultFolderStyle = kFolderStyleGlass;
+inline constexpr int kDefaultFolderStyle = kFolderStyleSimple;
 
 struct Folder {
     std::uint32_t id = 0;

--- a/projects/menu/src/core/FolderStore.hpp
+++ b/projects/menu/src/core/FolderStore.hpp
@@ -16,6 +16,19 @@ inline constexpr int kFolderStyleManila = 5;
 inline constexpr int kFolderStyleLabel = 6;
 inline constexpr int kFolderStyleCount = 7;
 inline constexpr int kDefaultFolderStyle = kFolderStyleClassic;
+inline constexpr int kMaxFolderPages = 8;
+
+inline constexpr std::size_t folderSlotsPerPage(int sizeIndex) {
+    switch (sizeIndex) {
+        case 0: return 4u * 2u;
+        case 2: return 6u * 4u;
+        default: return 5u * 3u;
+    }
+}
+
+inline constexpr std::size_t maxFolderSlots(int sizeIndex) {
+    return folderSlotsPerPage(sizeIndex) * static_cast<std::size_t>(kMaxFolderPages);
+}
 
 inline bool folderStyleSupportsCover(int styleIndex) {
     return styleIndex != kFolderStyleClassic;
@@ -37,10 +50,12 @@ struct Folder {
 };
 
 inline std::uint64_t firstCoverTitleId(const Folder& folder) {
-    return folder.titleIds.empty() ? 0 : folder.titleIds.front();
+    for (const std::uint64_t titleId : folder.titleIds) {
+        if (titleId != 0)
+            return titleId;
+    }
+    return 0;
 }
-
-inline constexpr int kMaxFolderPages = 8;
 
 class FolderStore final {
 public:

--- a/projects/menu/src/core/GridModel.hpp
+++ b/projects/menu/src/core/GridModel.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <utility>
 #include "WidgetStore.hpp"
+#include "FolderStore.hpp"
 
 
 enum class GridEntryKind : std::uint8_t {
@@ -36,6 +37,7 @@ struct AppEntry {
     std::uint32_t folderId = 0;
     int folderPreviewCount = 0;
     int folderColorIndex = 0;
+    int folderStyleIndex = switchu::folders::kDefaultFolderStyle;
     std::uint32_t widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int widgetColumns = 1;

--- a/projects/menu/src/core/GridModel.hpp
+++ b/projects/menu/src/core/GridModel.hpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include <utility>
 #include "WidgetStore.hpp"
-#include "FolderStore.hpp"
 
 
 enum class GridEntryKind : std::uint8_t {
@@ -37,7 +36,6 @@ struct AppEntry {
     std::uint32_t folderId = 0;
     int folderPreviewCount = 0;
     int folderColorIndex = 0;
-    int folderStyleIndex = switchu::folders::kDefaultFolderStyle;
     std::uint32_t widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int widgetColumns = 1;

--- a/projects/menu/src/core/GridModel.hpp
+++ b/projects/menu/src/core/GridModel.hpp
@@ -36,6 +36,7 @@ struct AppEntry {
     std::uint32_t folderId = 0;
     int folderPreviewCount = 0;
     int folderColorIndex = 0;
+    std::uint64_t folderCoverTitleId = 0;
     std::uint32_t widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int widgetColumns = 1;

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -268,7 +268,6 @@ bool appEntriesRefreshEquivalent(const AppEntry& a, const AppEntry& b) {
            a.folderId == b.folderId &&
            a.folderPreviewCount == b.folderPreviewCount &&
            a.folderColorIndex == b.folderColorIndex &&
-           a.folderStyleIndex == b.folderStyleIndex &&
            a.widgetId == b.widgetId &&
            a.widgetType == b.widgetType &&
            a.widgetColumns == b.widgetColumns &&
@@ -1088,7 +1087,6 @@ void WiiUMenuApp::composeRootPending(std::vector<PendingApp>& apps) {
         item.folderId = folder.id;
         item.folderPreviewCount = static_cast<int>(folder.titleCount());
         item.folderColorIndex = folder.colorIndex;
-        item.folderStyleIndex = folder.styleIndex;
         itemOrder.push_back(item.titleId);
         byId.emplace(item.titleId, std::move(item));
     }
@@ -1259,7 +1257,6 @@ GridModel WiiUMenuApp::buildRootFolderModel() {
         entry.folderId = folder.id;
         entry.folderPreviewCount = static_cast<int>(folder.titleCount());
         entry.folderColorIndex = folder.colorIndex;
-        entry.folderStyleIndex = folder.styleIndex;
         entries.emplace(entry.titleId, std::move(entry));
     }
     for (const auto& widget : m_widgetStore.all()) {
@@ -2903,7 +2900,7 @@ std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
     icon->setFolderPreviewCount(entry.folderPreviewCount);
     icon->setFolderVisualSeed(entry.folderId);
     icon->setFolderColorIndex(entry.folderColorIndex);
-    icon->setFolderStyleIndex(entry.folderStyleIndex);
+    icon->setFolderStyleIndex(m_config.folderStyle);
     if (entry.kind == GridEntryKind::WidgetContinuation) {
         icon->setTag("widget_continuation");
         icon->setFocusable(false);

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -268,6 +268,7 @@ bool appEntriesRefreshEquivalent(const AppEntry& a, const AppEntry& b) {
            a.folderId == b.folderId &&
            a.folderPreviewCount == b.folderPreviewCount &&
            a.folderColorIndex == b.folderColorIndex &&
+           a.folderStyleIndex == b.folderStyleIndex &&
            a.widgetId == b.widgetId &&
            a.widgetType == b.widgetType &&
            a.widgetColumns == b.widgetColumns &&
@@ -1087,6 +1088,7 @@ void WiiUMenuApp::composeRootPending(std::vector<PendingApp>& apps) {
         item.folderId = folder.id;
         item.folderPreviewCount = static_cast<int>(folder.titleCount());
         item.folderColorIndex = folder.colorIndex;
+        item.folderStyleIndex = folder.styleIndex;
         itemOrder.push_back(item.titleId);
         byId.emplace(item.titleId, std::move(item));
     }
@@ -1257,6 +1259,7 @@ GridModel WiiUMenuApp::buildRootFolderModel() {
         entry.folderId = folder.id;
         entry.folderPreviewCount = static_cast<int>(folder.titleCount());
         entry.folderColorIndex = folder.colorIndex;
+        entry.folderStyleIndex = folder.styleIndex;
         entries.emplace(entry.titleId, std::move(entry));
     }
     for (const auto& widget : m_widgetStore.all()) {
@@ -1571,6 +1574,10 @@ void WiiUMenuApp::applyDisplayModel(GridModel model, std::uint64_t focusId, bool
     m_widgetAssetPage = -1;
     if (animate) m_grid->startAppearAnimation();
     else for (auto& icon : m_grid->allIcons()) icon->forceVisible();
+    // Safety net for any rebuild while moving: never leave an out-of-range
+    // placement index (that pins the ghost at the origin).
+    if (m_editMode && (m_editTargetIndex < 0 || m_editTargetIndex >= m_model.count()))
+        syncEditPlacementAfterModelChange(m_openFolderId != 0);
     updateCursor();
 }
 
@@ -2741,11 +2748,16 @@ void WiiUMenuApp::openCapturedFolder() {
         m_folderHeaderLabel->setTextColor(m_theme.textPrimary);
     }
     m_grid->setRect({kGridRectX, 148.f, kGridRectW, 470.f});
+    // Don't inherit the root page number into the folder grid.
+    m_grid->setPage(0);
     applyDisplayModel(buildOpenFolderModel(m_openFolderId), m_folderOpenFocusTitleId, false);
     m_folderOpenFocusTitleId = 0;
     syncPageIndicator();
-    if (m_editMode)
+    if (m_editMode) {
+        // Always re-anchor: the previous target was a root-grid index.
+        syncEditPlacementAfterModelChange(true);
         reattachEditSourceIcon();
+    }
     if (!refocus)
         m_audio.playSfx(Sfx::ModalShow);
 }
@@ -2769,6 +2781,9 @@ void WiiUMenuApp::closeFolder(bool preserveEditMode) {
     applyDisplayModel(buildRootFolderModel(), folderTitleId(oldId), false);
     syncPageIndicator();
     if (preserveEditMode) {
+        // Focus is on the folder we just left; use that as the root placement target.
+        m_editTargetIndex = findTitleIndex(folderTitleId(oldId));
+        syncEditPlacementAfterModelChange(false);
         reattachEditSourceIcon();
         m_titlePill->setText(nxui::I18n::instance().tr("game.move_prefix", "Move: ") + m_editHeldTitle);
         m_titlePill->setVisible(true);
@@ -2888,6 +2903,7 @@ std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
     icon->setFolderPreviewCount(entry.folderPreviewCount);
     icon->setFolderVisualSeed(entry.folderId);
     icon->setFolderColorIndex(entry.folderColorIndex);
+    icon->setFolderStyleIndex(entry.folderStyleIndex);
     if (entry.kind == GridEntryKind::WidgetContinuation) {
         icon->setTag("widget_continuation");
         icon->setFocusable(false);

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -445,7 +445,7 @@ bool WiiUMenuApp::saveLeaveFrame(nxui::Renderer& ren) {
     std::vector<std::uint8_t> rgba;
     int width = 0;
     int height = 0;
-    if (!ren.downloadFramebufferRgba(rgba, width, height, true)) {
+    if (!ren.downloadFramebufferRgba(rgba, width, height, false)) {
         DebugLog::log("[leave] framebuffer download failed");
         return false;
     }
@@ -3186,7 +3186,9 @@ nxui::Texture* WiiUMenuApp::folderCoverTexture(std::uint64_t titleId) {
     if (data.empty() ||
         !tex->loadFromMemory(app().gpu(), app().renderer(), data.data(), data.size(), 192) ||
         !tex->valid()) {
-        m_folderCoverCache.emplace(titleId, nullptr);
+        // Icon data can be temporarily unavailable during an application-list
+        // refresh. Do not negative-cache the failure or this folder would keep
+        // its placeholder until the menu is restarted.
         return nullptr;
     }
     nxui::Texture* raw = tex.get();

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -268,6 +268,7 @@ bool appEntriesRefreshEquivalent(const AppEntry& a, const AppEntry& b) {
            a.folderId == b.folderId &&
            a.folderPreviewCount == b.folderPreviewCount &&
            a.folderColorIndex == b.folderColorIndex &&
+           a.folderCoverTitleId == b.folderCoverTitleId &&
            a.widgetId == b.widgetId &&
            a.widgetType == b.widgetType &&
            a.widgetColumns == b.widgetColumns &&
@@ -884,6 +885,18 @@ void WiiUMenuApp::reflowHomeGrid() {
             i < m_model.count() &&
             m_model.at(i).titleId == rebuiltModel.at(i).titleId) {
             icons.push_back(oldIcons[i]);
+            if (rebuiltModel.at(i).isFolder()) {
+                const auto& entry = rebuiltModel.at(i);
+                oldIcons[i]->setFolderPreviewCount(entry.folderPreviewCount);
+                oldIcons[i]->setFolderColorIndex(entry.folderColorIndex);
+                oldIcons[i]->setFolderCoverTitleId(entry.folderCoverTitleId);
+                oldIcons[i]->setFolderStyleIndex(m_config.folderStyle);
+                oldIcons[i]->setFolderShowCover(m_config.folderShowCover);
+                oldIcons[i]->setFolderCoverTexture(
+                    switchu::folders::folderShouldShowCover(
+                        m_config.folderStyle, m_config.folderShowCover)
+                        ? folderCoverTexture(entry.folderCoverTitleId) : nullptr);
+            }
         } else {
             auto icon = makeIcon(rebuiltModel.at(i));
             icon->setBaseColor(m_theme.iconDefault);
@@ -1087,6 +1100,7 @@ void WiiUMenuApp::composeRootPending(std::vector<PendingApp>& apps) {
         item.folderId = folder.id;
         item.folderPreviewCount = static_cast<int>(folder.titleCount());
         item.folderColorIndex = folder.colorIndex;
+        item.folderCoverTitleId = switchu::folders::firstCoverTitleId(folder);
         itemOrder.push_back(item.titleId);
         byId.emplace(item.titleId, std::move(item));
     }
@@ -1257,6 +1271,7 @@ GridModel WiiUMenuApp::buildRootFolderModel() {
         entry.folderId = folder.id;
         entry.folderPreviewCount = static_cast<int>(folder.titleCount());
         entry.folderColorIndex = folder.colorIndex;
+        entry.folderCoverTitleId = switchu::folders::firstCoverTitleId(folder);
         entries.emplace(entry.titleId, std::move(entry));
     }
     for (const auto& widget : m_widgetStore.all()) {
@@ -2894,6 +2909,41 @@ void WiiUMenuApp::activateApplication(GlossyIcon* source, AppEntry* entry,
 }
 #endif
 
+nxui::Texture* WiiUMenuApp::folderCoverTexture(std::uint64_t titleId) {
+    if (titleId == 0)
+        return nullptr;
+    auto it = m_folderCoverCache.find(titleId);
+    if (it != m_folderCoverCache.end())
+        return it->second.get();
+
+    auto tex = std::make_unique<nxui::Texture>();
+    const auto data = AppListLoader::loadIconData(titleId);
+    if (data.empty() ||
+        !tex->loadFromMemory(app().gpu(), app().renderer(), data.data(), data.size(), 192) ||
+        !tex->valid()) {
+        m_folderCoverCache.emplace(titleId, nullptr);
+        return nullptr;
+    }
+    nxui::Texture* raw = tex.get();
+    m_folderCoverCache.emplace(titleId, std::move(tex));
+    return raw;
+}
+
+void WiiUMenuApp::applyFolderCoversToIcons() {
+    if (!m_grid)
+        return;
+    const bool wantCover = switchu::folders::folderShouldShowCover(
+        m_config.folderStyle, m_config.folderShowCover);
+    const auto& icons = m_grid->allIcons();
+    for (int i = 0; i < m_model.count() && i < static_cast<int>(icons.size()); ++i) {
+        if (!m_model.at(i).isFolder() || !icons[static_cast<std::size_t>(i)])
+            continue;
+        icons[static_cast<std::size_t>(i)]->setFolderShowCover(m_config.folderShowCover);
+        icons[static_cast<std::size_t>(i)]->setFolderCoverTexture(
+            wantCover ? folderCoverTexture(m_model.at(i).folderCoverTitleId) : nullptr);
+    }
+}
+
 std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
     auto icon = std::make_shared<GlossyIcon>();
     icon->setEntryKind(entry.kind);
@@ -3028,6 +3078,11 @@ std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
         icon->setOnActivate([this, folderId]() {
             requestOpenFolder(folderId);
         });
+        icon->setFolderCoverTitleId(entry.folderCoverTitleId);
+        icon->setFolderShowCover(m_config.folderShowCover);
+        if (switchu::folders::folderShouldShowCover(m_config.folderStyle,
+                                                    m_config.folderShowCover))
+            icon->setFolderCoverTexture(folderCoverTexture(entry.folderCoverTitleId));
         return icon;
     }
 

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -2901,6 +2901,7 @@ std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
     icon->setFolderVisualSeed(entry.folderId);
     icon->setFolderColorIndex(entry.folderColorIndex);
     icon->setFolderStyleIndex(m_config.folderStyle);
+    icon->setThemeMode(m_theme.mode);
     if (entry.kind == GridEntryKind::WidgetContinuation) {
         icon->setTag("widget_continuation");
         icon->setFocusable(false);

--- a/projects/menu/src/core/WiiUMenuApp.hpp
+++ b/projects/menu/src/core/WiiUMenuApp.hpp
@@ -258,6 +258,10 @@ private:
     void reattachEditSourceIcon();
     void stopEditGhost();
     void updateEditGhost(float dt);
+    // Re-anchor move-mode placement after the grid model changes (folder
+    // open/close, rebuild). preferEmptySlot is used when dropping into a
+    // folder so the cursor starts on a free cell instead of a stale root index.
+    void syncEditPlacementAfterModelChange(bool preferEmptySlot);
     bool commitEditModePlacement();
     bool activateEditModeTarget();
     bool moveFocusedIcon(nxui::FocusDirection dir);

--- a/projects/menu/src/core/WiiUMenuApp.hpp
+++ b/projects/menu/src/core/WiiUMenuApp.hpp
@@ -227,6 +227,8 @@ private:
     void closeActiveOverlays();
     void handleTouch();
     std::shared_ptr<GlossyIcon> makeIcon(const AppEntry& entry);
+    nxui::Texture* folderCoverTexture(std::uint64_t titleId);
+    void applyFolderCoversToIcons();
     void wireFocusCallback();
     void wireGlobalActions();
     void toggleAccessibilitySpeech();
@@ -400,6 +402,7 @@ private:
     std::vector<uint64_t> m_layoutSlots;
     std::unordered_map<std::uint64_t, switchu::widgets::WidgetSize> m_gameSizes;
     bool m_layoutDirty = false;
+    std::unordered_map<std::uint64_t, std::unique_ptr<nxui::Texture>> m_folderCoverCache;
     switchu::folders::FolderStore m_folderStore;
     switchu::widgets::WidgetStore m_widgetStore;
     std::uint64_t m_recentWidgetAssetTitleId = 0;

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -267,6 +267,55 @@ void WiiUMenuApp::reattachEditSourceIcon() {
         m_editGhostIcon->setTexture(m_editSourceIcon->texture());
 }
 
+void WiiUMenuApp::syncEditPlacementAfterModelChange(bool preferEmptySlot) {
+    if (!m_editMode || !m_grid || m_model.count() <= 0)
+        return;
+
+    const int count = m_model.count();
+    int target = m_editTargetIndex;
+    const bool stale = target < 0 || target >= count;
+
+    if (preferEmptySlot || stale) {
+        target = 0;
+        if (preferEmptySlot) {
+            for (int i = 0; i < count; ++i) {
+                const auto& entry = m_model.at(i);
+                if (entry.kind == GridEntryKind::Empty ||
+                    (entry.titleId == 0 &&
+                     entry.kind != GridEntryKind::WidgetContinuation)) {
+                    target = i;
+                    break;
+                }
+            }
+        } else {
+            const int focused = m_grid->focusedGlobalIndex();
+            if (focused >= 0 && focused < count)
+                target = focused;
+        }
+    }
+
+    m_editTargetIndex = std::clamp(target, 0, count - 1);
+    if (m_grid->focusGlobalIndex(m_editTargetIndex)) {
+        if (auto* focused = m_grid->focusManager().current()) {
+            focusManager().setFocus(focused);
+            if (focused->tag() == "glossy_icon")
+                bindEditActions(static_cast<GlossyIcon*>(focused));
+        }
+    }
+
+    const int spanColumns = m_editGhostIcon
+        ? std::max(1, m_editGhostIcon->gridSpanColumns()) : 1;
+    const int spanRows = m_editGhostIcon
+        ? std::max(1, m_editGhostIcon->gridSpanRows()) : 1;
+    m_editGhostTargetRect = m_grid->gridSpanRect(
+        m_editTargetIndex, spanColumns, spanRows);
+    if (m_editGhostIcon)
+        m_editGhostIcon->setRect(m_editGhostTargetRect);
+    updateCursor();
+    DebugLog::log("[edit] sync placement target=%d preferEmpty=%d stale=%d",
+                  m_editTargetIndex, preferEmptySlot ? 1 : 0, stale ? 1 : 0);
+}
+
 void WiiUMenuApp::updateEditGhost(float dt) {
     if (!m_editMode || !m_editGhostIcon)
         return;
@@ -618,6 +667,10 @@ bool WiiUMenuApp::activateEditModeTarget() {
     const AppEntry targetEntry = m_model.at(target);
     if (m_openFolderId == 0 && targetEntry.isFolder() &&
         m_editHeldTitleId < kFolderTitleIdPrefix) {
+        // Drop the root-grid index before the folder model loads. Leaving it
+        // intact made page-2+ folders keep an out-of-range target, which pinned
+        // the edit ghost at (0,0) and blocked further movement (#95).
+        m_editTargetIndex = -1;
         detachEditSourceIcon();
         unbindEditActions();
         requestOpenFolder(targetEntry.folderId);
@@ -1233,6 +1286,7 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
     info.itemCount = static_cast<int>(folder->titleCount());
     info.colorIndex = folder->colorIndex;
     info.sizeIndex = folder->sizeIndex;
+    info.styleIndex = folder->styleIndex;
     m_folderOptions->setFolder(info);
     m_folderOptions->onOpen([this, folderId]() {
         if (m_folderOptions) m_folderOptions->hide();
@@ -1263,6 +1317,19 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
         if (!m_folderStore.setSizeIndex(folderId, sizeIndex))
             return;
         saveFoldersOrReport("folder_size");
+    });
+    m_folderOptions->onStyleChange([this, folderId](int styleIndex) {
+        if (!m_folderStore.setStyleIndex(folderId, styleIndex) ||
+            !saveFoldersOrReport("folder_style"))
+            return;
+        const std::uint64_t id = folderTitleId(folderId);
+        const int index = findTitleIndex(id);
+        if (index >= 0 && index < m_model.count()) {
+            m_model.at(index).folderStyleIndex = styleIndex;
+            const auto& icons = m_grid->allIcons();
+            if (index < static_cast<int>(icons.size()) && icons[static_cast<std::size_t>(index)])
+                icons[static_cast<std::size_t>(index)]->setFolderStyleIndex(styleIndex);
+        }
     });
     m_folderOptions->onDelete([this, folderId, name]() {
         auto& local = nxui::I18n::instance();

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -1286,7 +1286,7 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
     info.itemCount = static_cast<int>(folder->titleCount());
     info.colorIndex = folder->colorIndex;
     info.sizeIndex = folder->sizeIndex;
-    info.styleIndex = folder->styleIndex;
+    info.styleIndex = m_config.folderStyle;
     m_folderOptions->setFolder(info);
     m_folderOptions->onOpen([this, folderId]() {
         if (m_folderOptions) m_folderOptions->hide();
@@ -1318,17 +1318,23 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
             return;
         saveFoldersOrReport("folder_size");
     });
-    m_folderOptions->onStyleChange([this, folderId](int styleIndex) {
-        if (!m_folderStore.setStyleIndex(folderId, styleIndex) ||
-            !saveFoldersOrReport("folder_style"))
+    m_folderOptions->onStyleChange([this](int styleIndex) {
+        const int clamped = std::clamp(styleIndex, 0, switchu::folders::kFolderStyleCount - 1);
+        if (m_config.folderStyle == clamped)
             return;
-        const std::uint64_t id = folderTitleId(folderId);
-        const int index = findTitleIndex(id);
-        if (index >= 0 && index < m_model.count()) {
-            m_model.at(index).folderStyleIndex = styleIndex;
-            const auto& icons = m_grid->allIcons();
-            if (index < static_cast<int>(icons.size()) && icons[static_cast<std::size_t>(index)])
-                icons[static_cast<std::size_t>(index)]->setFolderStyleIndex(styleIndex);
+        m_config.folderStyle = clamped;
+        if (m_configSaveFuture.valid())
+            m_configSaveFuture.wait();
+        m_configSaveFuture = m_threadPool.submit([config = m_config]() {
+            config.save();
+        });
+        if (!m_grid)
+            return;
+        const auto& icons = m_grid->allIcons();
+        for (int i = 0; i < m_model.count() && i < static_cast<int>(icons.size()); ++i) {
+            if (!m_model.at(i).isFolder() || !icons[static_cast<std::size_t>(i)])
+                continue;
+            icons[static_cast<std::size_t>(i)]->setFolderStyleIndex(clamped);
         }
     });
     m_folderOptions->onDelete([this, folderId, name]() {

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -1287,6 +1287,7 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
     info.colorIndex = folder->colorIndex;
     info.sizeIndex = folder->sizeIndex;
     info.styleIndex = m_config.folderStyle;
+    info.showCover = m_config.folderShowCover;
     m_folderOptions->setFolder(info);
     m_folderOptions->onOpen([this, folderId]() {
         if (m_folderOptions) m_folderOptions->hide();
@@ -1336,6 +1337,18 @@ void WiiUMenuApp::showFolderContextMenu(std::uint32_t folderId) {
                 continue;
             icons[static_cast<std::size_t>(i)]->setFolderStyleIndex(clamped);
         }
+        applyFolderCoversToIcons();
+    });
+    m_folderOptions->onCoverChange([this](bool showCover) {
+        if (m_config.folderShowCover == showCover)
+            return;
+        m_config.folderShowCover = showCover;
+        if (m_configSaveFuture.valid())
+            m_configSaveFuture.wait();
+        m_configSaveFuture = m_threadPool.submit([config = m_config]() {
+            config.save();
+        });
+        applyFolderCoversToIcons();
     });
     m_folderOptions->onDelete([this, folderId, name]() {
         auto& local = nxui::I18n::instance();

--- a/projects/menu/src/core/WiiUMenuAppSettings.cpp
+++ b/projects/menu/src/core/WiiUMenuAppSettings.cpp
@@ -726,9 +726,11 @@ void WiiUMenuApp::syncSteamGridDb() {
                 m_recentWidgetIcon.reset();
             }
             if (result.kind == SteamGridDbManager::ArtworkKind::Icon && m_grid) {
+                m_folderCoverCache.erase(result.titleId);
                 m_iconStreamer.reloadTitle(result.titleId, m_grid->currentPage(),
                                            m_grid->iconsPerPage(), app().gpu(),
                                            app().renderer(), m_grid->allIcons());
+                applyFolderCoversToIcons();
             } else {
                 showFocusedSteamGridDbArtwork(true);
             }

--- a/projects/menu/src/core/WiiUMenuAppSettings.cpp
+++ b/projects/menu/src/core/WiiUMenuAppSettings.cpp
@@ -1712,6 +1712,7 @@ void WiiUMenuApp::applyTheme() {
         icon->setHighlightColor(m_theme.panelHighlight);
         icon->setCornerRadius(m_theme.iconCornerRadius);
         icon->setLoadingColor(m_theme.cursorNormal);
+        icon->setThemeMode(m_theme.mode);
     }
     DebugLog::log("[theme-apply] widget recolor grid icons done");
 

--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -191,6 +191,7 @@ void registerEntries(std::vector<PendingApp>& apps,
         entry.folderId = p.folderId;
         entry.folderPreviewCount = p.folderPreviewCount;
         entry.folderColorIndex = p.folderColorIndex;
+        entry.folderStyleIndex = p.folderStyleIndex;
         entry.widgetId = p.widgetId;
         entry.widgetType = p.widgetType;
         entry.widgetColumns = p.widgetColumns;

--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -191,7 +191,6 @@ void registerEntries(std::vector<PendingApp>& apps,
         entry.folderId = p.folderId;
         entry.folderPreviewCount = p.folderPreviewCount;
         entry.folderColorIndex = p.folderColorIndex;
-        entry.folderStyleIndex = p.folderStyleIndex;
         entry.widgetId = p.widgetId;
         entry.widgetType = p.widgetType;
         entry.widgetColumns = p.widgetColumns;

--- a/projects/menu/src/launcher/AppListLoader.cpp
+++ b/projects/menu/src/launcher/AppListLoader.cpp
@@ -191,6 +191,7 @@ void registerEntries(std::vector<PendingApp>& apps,
         entry.folderId = p.folderId;
         entry.folderPreviewCount = p.folderPreviewCount;
         entry.folderColorIndex = p.folderColorIndex;
+        entry.folderCoverTitleId = p.folderCoverTitleId;
         entry.widgetId = p.widgetId;
         entry.widgetType = p.widgetType;
         entry.widgetColumns = p.widgetColumns;

--- a/projects/menu/src/launcher/AppListLoader.hpp
+++ b/projects/menu/src/launcher/AppListLoader.hpp
@@ -28,6 +28,7 @@ struct PendingApp {
     std::uint32_t        folderId = 0;
     int                  folderPreviewCount = 0;
     int                  folderColorIndex = 0;
+    int                  folderStyleIndex = switchu::folders::kDefaultFolderStyle;
     std::uint32_t        widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int                  widgetColumns = 1;

--- a/projects/menu/src/launcher/AppListLoader.hpp
+++ b/projects/menu/src/launcher/AppListLoader.hpp
@@ -28,7 +28,6 @@ struct PendingApp {
     std::uint32_t        folderId = 0;
     int                  folderPreviewCount = 0;
     int                  folderColorIndex = 0;
-    int                  folderStyleIndex = switchu::folders::kDefaultFolderStyle;
     std::uint32_t        widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int                  widgetColumns = 1;

--- a/projects/menu/src/launcher/AppListLoader.hpp
+++ b/projects/menu/src/launcher/AppListLoader.hpp
@@ -28,6 +28,7 @@ struct PendingApp {
     std::uint32_t        folderId = 0;
     int                  folderPreviewCount = 0;
     int                  folderColorIndex = 0;
+    std::uint64_t        folderCoverTitleId = 0;
     std::uint32_t        widgetId = 0;
     switchu::widgets::WidgetType widgetType = switchu::widgets::WidgetType::Clock;
     int                  widgetColumns = 1;

--- a/projects/menu/src/settings/FolderOptionsScreen.cpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.cpp
@@ -1,5 +1,6 @@
 #include "FolderOptionsScreen.hpp"
 #include "widgets/FolderPalette.hpp"
+#include "core/FolderStore.hpp"
 #include <nxui/core/I18n.hpp>
 #include <nxui/core/Renderer.hpp>
 #include <algorithm>
@@ -29,6 +30,8 @@ void FolderOptionsScreen::setFolder(const FolderInfo& info) {
     m_folder = info;
     m_folder.colorIndex = std::clamp(m_folder.colorIndex, 0, 7);
     m_folder.sizeIndex = std::clamp(m_folder.sizeIndex, 0, 2);
+    m_folder.styleIndex = std::clamp(m_folder.styleIndex, 0,
+                                     switchu::folders::kFolderStyleCount - 1);
     m_tabs.clear();
     m_cachedTabContentWidgets.clear();
     warmup();
@@ -78,6 +81,23 @@ void FolderOptionsScreen::buildTabs() {
         if (m_sizeCb) m_sizeCb(m_folder.sizeIndex);
     };
     appearance.items.push_back(std::move(size));
+
+    SettingItem style;
+    style.label = i18n.tr("folder.style", "Folder style");
+    style.description = i18n.tr(
+        "folder.style_desc", "Choose the classic tile look or a translucent glass look.");
+    style.type = ItemType::Selector;
+    style.options = {
+        i18n.tr("folder.style_classic", "Classic"),
+        i18n.tr("folder.style_glass", "Glass"),
+    };
+    style.intVal = m_folder.styleIndex;
+    style.onChange = [this](SettingItem& self) {
+        m_folder.styleIndex = std::clamp(self.intVal, 0,
+                                         switchu::folders::kFolderStyleCount - 1);
+        if (m_styleCb) m_styleCb(m_folder.styleIndex);
+    };
+    appearance.items.push_back(std::move(style));
     m_tabs.push_back(std::move(appearance));
 
     Tab management;
@@ -119,25 +139,40 @@ void FolderOptionsScreen::drawOverlayHeader(nxui::Renderer& ren,
         return;
 
     const nxui::Rect shell{panel.x + 30.f, panel.y + 24.f, 92.f, 92.f};
-    ren.drawRoundedRect({shell.x, shell.y + 5.f, shell.width, shell.height},
-                        nxui::Color::black().withAlpha(0.22f * opacity), 18.f);
-    ren.drawRoundedRect(shell, nxui::Color(0.92f, 0.95f, 0.94f, 0.96f * opacity), 18.f);
-    ren.drawRoundedRectOutline(shell.shrunk(1.f),
-                               nxui::Color::white().withAlpha(0.90f * opacity),
-                               17.f, 2.f);
-
     const nxui::Color accent = switchu::folders::colorForIndex(m_folder.colorIndex);
-    constexpr float cell = 19.f;
-    constexpr float gap = 4.f;
-    const float gridSize = cell * 3.f + gap * 2.f;
-    const float gx = shell.x + (shell.width - gridSize) * 0.5f;
-    const float gy = shell.y + (shell.height - gridSize) * 0.5f;
-    for (int i = 0; i < 9; ++i) {
-        nxui::Rect tile{gx + (i % 3) * (cell + gap),
-                        gy + (i / 3) * (cell + gap), cell, cell};
-        ren.drawRoundedRect(tile, accent.withAlpha(0.96f * opacity), 4.f);
-        ren.drawRoundedRect({tile.x + 2.f, tile.y + 2.f, tile.width - 4.f, 3.f},
-                            nxui::Color::white().withAlpha(0.20f * opacity), 1.5f);
+    const bool classic = m_folder.styleIndex == switchu::folders::kFolderStyleClassic;
+
+    if (classic) {
+        ren.drawRoundedRect({shell.x, shell.y + 5.f, shell.width, shell.height},
+                            nxui::Color::black().withAlpha(0.22f * opacity), 18.f);
+        ren.drawRoundedRect(shell, nxui::Color(0.92f, 0.95f, 0.94f, 0.96f * opacity), 18.f);
+        ren.drawRoundedRectOutline(shell.shrunk(1.f),
+                                   nxui::Color::white().withAlpha(0.90f * opacity),
+                                   17.f, 2.f);
+
+        constexpr float cell = 19.f;
+        constexpr float gap = 4.f;
+        const float gridSize = cell * 3.f + gap * 2.f;
+        const float gx = shell.x + (shell.width - gridSize) * 0.5f;
+        const float gy = shell.y + (shell.height - gridSize) * 0.5f;
+        for (int i = 0; i < 9; ++i) {
+            nxui::Rect tile{gx + (i % 3) * (cell + gap),
+                            gy + (i / 3) * (cell + gap), cell, cell};
+            ren.drawRoundedRect(tile, accent.withAlpha(0.96f * opacity), 4.f);
+            ren.drawRoundedRect({tile.x + 2.f, tile.y + 2.f, tile.width - 4.f, 3.f},
+                                nxui::Color::white().withAlpha(0.20f * opacity), 1.5f);
+        }
+    } else {
+        ren.drawRoundedRect(shell,
+                            nxui::Color(0.04f, 0.07f, 0.11f, 0.50f * opacity), 18.f);
+        ren.drawRoundedRect(shell, accent.withAlpha(0.18f * opacity), 18.f);
+        ren.drawRoundedRectOutline(shell.shrunk(1.f),
+                                   nxui::Color::white().withAlpha(0.40f * opacity),
+                                   17.f, 1.5f);
+        ren.drawRoundedRect({shell.x + 8.f, shell.y + 8.f, shell.width - 16.f, 10.f},
+                            accent.withAlpha(0.82f * opacity), 4.f);
+        ren.drawRoundedRect({shell.x + 14.f, shell.y + 42.f, shell.width - 28.f, 22.f},
+                            nxui::Color(0.02f, 0.04f, 0.08f, 0.55f * opacity), 8.f);
     }
 
     const float textX = shell.right() + 24.f;

--- a/projects/menu/src/settings/FolderOptionsScreen.cpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.cpp
@@ -85,7 +85,8 @@ void FolderOptionsScreen::buildTabs() {
     SettingItem style;
     style.label = i18n.tr("folder.style", "Folder style");
     style.description = i18n.tr(
-        "folder.style_desc", "Choose the classic tile look or a translucent glass look.");
+        "folder.style_desc",
+        "Applies Classic or Glass to every folder, including new ones.");
     style.type = ItemType::Selector;
     style.options = {
         i18n.tr("folder.style_classic", "Classic"),

--- a/projects/menu/src/settings/FolderOptionsScreen.cpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.cpp
@@ -171,11 +171,14 @@ void FolderOptionsScreen::drawOverlayHeader(nxui::Renderer& ren,
         const nxui::Color shellOutline = lightTheme
             ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * opacity)
             : nxui::Color::white().withAlpha(0.28f * opacity);
+        const nxui::Rect inner = shell.shrunk(1.f);
+        const float sliceH = std::max(8.f, shell.height * 0.09f);
         ren.drawRoundedRect(shell, shellFill, 18.f);
         ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * opacity), 18.f);
-        ren.drawRoundedRectOutline(shell.shrunk(1.f), shellOutline, 17.f, 1.5f);
-        ren.drawRoundedRect({shell.x + 8.f, shell.y + 8.f, shell.width - 16.f, 10.f},
-                            accent.withAlpha(0.82f * opacity), 4.f);
+        ren.pushClipRect({inner.x, inner.y, inner.width, sliceH});
+        ren.drawRoundedRect(inner, accent.withAlpha(0.82f * opacity), 17.f);
+        ren.popClipRect();
+        ren.drawRoundedRectOutline(inner, shellOutline, 17.f, 1.5f);
     }
 
     const float textX = shell.right() + 24.f;

--- a/projects/menu/src/settings/FolderOptionsScreen.cpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.cpp
@@ -86,11 +86,11 @@ void FolderOptionsScreen::buildTabs() {
     style.label = i18n.tr("folder.style", "Folder style");
     style.description = i18n.tr(
         "folder.style_desc",
-        "Applies Classic or Glass to every folder, including new ones.");
+        "Applies Classic or Simple to every folder, including new ones. Simple follows the active theme.");
     style.type = ItemType::Selector;
     style.options = {
         i18n.tr("folder.style_classic", "Classic"),
-        i18n.tr("folder.style_glass", "Glass"),
+        i18n.tr("folder.style_simple", "Simple"),
     };
     style.intVal = m_folder.styleIndex;
     style.onChange = [this](SettingItem& self) {
@@ -164,16 +164,18 @@ void FolderOptionsScreen::drawOverlayHeader(nxui::Renderer& ren,
                                 nxui::Color::white().withAlpha(0.20f * opacity), 1.5f);
         }
     } else {
-        ren.drawRoundedRect(shell,
-                            nxui::Color(0.04f, 0.07f, 0.11f, 0.50f * opacity), 18.f);
-        ren.drawRoundedRect(shell, accent.withAlpha(0.18f * opacity), 18.f);
-        ren.drawRoundedRectOutline(shell.shrunk(1.f),
-                                   nxui::Color::white().withAlpha(0.40f * opacity),
-                                   17.f, 1.5f);
+        const bool lightTheme = m_theme && m_theme->mode == nxui::ThemeMode::Light;
+        const nxui::Color shellFill = lightTheme
+            ? nxui::Color(0.94f, 0.96f, 0.97f, 0.96f * opacity)
+            : nxui::Color(0.10f, 0.13f, 0.17f, 0.92f * opacity);
+        const nxui::Color shellOutline = lightTheme
+            ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * opacity)
+            : nxui::Color::white().withAlpha(0.28f * opacity);
+        ren.drawRoundedRect(shell, shellFill, 18.f);
+        ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * opacity), 18.f);
+        ren.drawRoundedRectOutline(shell.shrunk(1.f), shellOutline, 17.f, 1.5f);
         ren.drawRoundedRect({shell.x + 8.f, shell.y + 8.f, shell.width - 16.f, 10.f},
                             accent.withAlpha(0.82f * opacity), 4.f);
-        ren.drawRoundedRect({shell.x + 14.f, shell.y + 42.f, shell.width - 28.f, 22.f},
-                            nxui::Color(0.02f, 0.04f, 0.08f, 0.55f * opacity), 8.f);
     }
 
     const float textX = shell.right() + 24.f;

--- a/projects/menu/src/settings/FolderOptionsScreen.cpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.cpp
@@ -1,5 +1,6 @@
 #include "FolderOptionsScreen.hpp"
 #include "widgets/FolderPalette.hpp"
+#include "widgets/FolderStyleDraw.hpp"
 #include "core/FolderStore.hpp"
 #include <nxui/core/I18n.hpp>
 #include <nxui/core/Renderer.hpp>
@@ -86,11 +87,16 @@ void FolderOptionsScreen::buildTabs() {
     style.label = i18n.tr("folder.style", "Folder style");
     style.description = i18n.tr(
         "folder.style_desc",
-        "Applies Classic or Simple to every folder, including new ones. Simple follows the active theme.");
+        "Applies to every folder, including new ones.");
     style.type = ItemType::Selector;
     style.options = {
         i18n.tr("folder.style_classic", "Classic"),
         i18n.tr("folder.style_simple", "Simple"),
+        i18n.tr("folder.style_minimal", "Minimal"),
+        i18n.tr("folder.style_tab", "Tab"),
+        i18n.tr("folder.style_ring", "Ring"),
+        i18n.tr("folder.style_manila", "Manila"),
+        i18n.tr("folder.style_label", "Label"),
     };
     style.intVal = m_folder.styleIndex;
     style.onChange = [this](SettingItem& self) {
@@ -99,6 +105,20 @@ void FolderOptionsScreen::buildTabs() {
         if (m_styleCb) m_styleCb(m_folder.styleIndex);
     };
     appearance.items.push_back(std::move(style));
+
+    SettingItem cover;
+    cover.label = i18n.tr("folder.show_cover", "Show cover");
+    cover.description = i18n.tr(
+        "folder.show_cover_desc",
+        "Shows the first game on every folder. Classic keeps the mosaic instead.");
+    cover.type = ItemType::Toggle;
+    cover.boolVal = m_folder.showCover;
+    cover.anim01 = cover.boolVal ? 1.f : 0.f;
+    cover.onChange = [this](SettingItem& self) {
+        m_folder.showCover = self.boolVal;
+        if (m_coverCb) m_coverCb(m_folder.showCover);
+    };
+    appearance.items.push_back(std::move(cover));
     m_tabs.push_back(std::move(appearance));
 
     Tab management;
@@ -140,46 +160,19 @@ void FolderOptionsScreen::drawOverlayHeader(nxui::Renderer& ren,
         return;
 
     const nxui::Rect shell{panel.x + 30.f, panel.y + 24.f, 92.f, 92.f};
-    const nxui::Color accent = switchu::folders::colorForIndex(m_folder.colorIndex);
-    const bool classic = m_folder.styleIndex == switchu::folders::kFolderStyleClassic;
-
-    if (classic) {
-        ren.drawRoundedRect({shell.x, shell.y + 5.f, shell.width, shell.height},
-                            nxui::Color::black().withAlpha(0.22f * opacity), 18.f);
-        ren.drawRoundedRect(shell, nxui::Color(0.92f, 0.95f, 0.94f, 0.96f * opacity), 18.f);
-        ren.drawRoundedRectOutline(shell.shrunk(1.f),
-                                   nxui::Color::white().withAlpha(0.90f * opacity),
-                                   17.f, 2.f);
-
-        constexpr float cell = 19.f;
-        constexpr float gap = 4.f;
-        const float gridSize = cell * 3.f + gap * 2.f;
-        const float gx = shell.x + (shell.width - gridSize) * 0.5f;
-        const float gy = shell.y + (shell.height - gridSize) * 0.5f;
-        for (int i = 0; i < 9; ++i) {
-            nxui::Rect tile{gx + (i % 3) * (cell + gap),
-                            gy + (i / 3) * (cell + gap), cell, cell};
-            ren.drawRoundedRect(tile, accent.withAlpha(0.96f * opacity), 4.f);
-            ren.drawRoundedRect({tile.x + 2.f, tile.y + 2.f, tile.width - 4.f, 3.f},
-                                nxui::Color::white().withAlpha(0.20f * opacity), 1.5f);
-        }
-    } else {
-        const bool lightTheme = m_theme && m_theme->mode == nxui::ThemeMode::Light;
-        const nxui::Color shellFill = lightTheme
-            ? nxui::Color(0.94f, 0.96f, 0.97f, 0.96f * opacity)
-            : nxui::Color(0.10f, 0.13f, 0.17f, 0.92f * opacity);
-        const nxui::Color shellOutline = lightTheme
-            ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * opacity)
-            : nxui::Color::white().withAlpha(0.28f * opacity);
-        const nxui::Rect inner = shell.shrunk(1.f);
-        const float sliceH = std::max(8.f, shell.height * 0.09f);
-        ren.drawRoundedRect(shell, shellFill, 18.f);
-        ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * opacity), 18.f);
-        ren.pushClipRect({inner.x, inner.y, inner.width, sliceH});
-        ren.drawRoundedRect(inner, accent.withAlpha(0.82f * opacity), 17.f);
-        ren.popClipRect();
-        ren.drawRoundedRectOutline(inner, shellOutline, 17.f, 1.5f);
-    }
+    switchu::folders::FolderStyleDrawArgs preview;
+    preview.renderer = &ren;
+    preview.bounds = shell;
+    preview.radius = 18.f;
+    preview.scale = 1.f;
+    preview.opacity = opacity;
+    preview.styleIndex = m_folder.styleIndex;
+    preview.accent = switchu::folders::colorForIndex(m_folder.colorIndex);
+    preview.themeMode = m_theme->mode;
+    preview.drawName = false;
+    preview.showCover = m_folder.showCover;
+    preview.schematicPlaceholder = true;
+    switchu::folders::drawFolderStyle(preview);
 
     const float textX = shell.right() + 24.f;
     const float textW = std::max(0.f, panel.right() - 30.f - textX);

--- a/projects/menu/src/settings/FolderOptionsScreen.hpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.hpp
@@ -11,6 +11,7 @@ public:
         int itemCount = 0;
         int colorIndex = 0;
         int sizeIndex = 1;
+        int styleIndex = 1;
     };
 
     FolderOptionsScreen();
@@ -21,6 +22,7 @@ public:
     void onDelete(VoidCb cb) { m_deleteCb = std::move(cb); }
     void onColorChange(IntCb cb) { m_colorCb = std::move(cb); }
     void onSizeChange(IntCb cb) { m_sizeCb = std::move(cb); }
+    void onStyleChange(IntCb cb) { m_styleCb = std::move(cb); }
 
 protected:
     void buildTabs() override;
@@ -36,4 +38,5 @@ private:
     VoidCb m_deleteCb;
     IntCb m_colorCb;
     IntCb m_sizeCb;
+    IntCb m_styleCb;
 };

--- a/projects/menu/src/settings/FolderOptionsScreen.hpp
+++ b/projects/menu/src/settings/FolderOptionsScreen.hpp
@@ -11,7 +11,8 @@ public:
         int itemCount = 0;
         int colorIndex = 0;
         int sizeIndex = 1;
-        int styleIndex = 1;
+        int styleIndex = 0;
+        bool showCover = false;
     };
 
     FolderOptionsScreen();
@@ -23,6 +24,7 @@ public:
     void onColorChange(IntCb cb) { m_colorCb = std::move(cb); }
     void onSizeChange(IntCb cb) { m_sizeCb = std::move(cb); }
     void onStyleChange(IntCb cb) { m_styleCb = std::move(cb); }
+    void onCoverChange(BoolCb cb) { m_coverCb = std::move(cb); }
 
 protected:
     void buildTabs() override;
@@ -39,4 +41,5 @@ private:
     IntCb m_colorCb;
     IntCb m_sizeCb;
     IntCb m_styleCb;
+    BoolCb m_coverCb;
 };

--- a/projects/menu/src/widgets/FolderStyleDraw.cpp
+++ b/projects/menu/src/widgets/FolderStyleDraw.cpp
@@ -1,0 +1,349 @@
+#include "FolderStyleDraw.hpp"
+#include "core/FolderStore.hpp"
+#include <nxui/core/Font.hpp>
+#include <nxui/core/Renderer.hpp>
+#include <nxui/core/Texture.hpp>
+#include <algorithm>
+
+namespace switchu::folders {
+namespace {
+
+struct ThemeShell {
+    nxui::Color fill;
+    nxui::Color outline;
+    nxui::Color title;
+    bool light = false;
+};
+
+ThemeShell themeShell(nxui::ThemeMode mode, float opacity) {
+    ThemeShell out;
+    out.light = mode == nxui::ThemeMode::Light;
+    out.fill = out.light
+        ? nxui::Color(0.94f, 0.96f, 0.97f, 0.96f * opacity)
+        : nxui::Color(0.10f, 0.13f, 0.17f, 0.92f * opacity);
+    out.outline = out.light
+        ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * opacity)
+        : nxui::Color::white().withAlpha(0.28f * opacity);
+    out.title = out.light
+        ? nxui::Color(0.08f, 0.12f, 0.16f, 0.96f * opacity)
+        : nxui::Color::white().withAlpha(0.98f * opacity);
+    return out;
+}
+
+void drawHaloTitle(nxui::Renderer& ren, nxui::Font* font, const std::string& title,
+                   const nxui::Vec2& pos, float textScale, float scale, float opacity) {
+    const float halo = std::max(1.f, 1.5f * scale);
+    const nxui::Color shadow(0.05f, 0.16f, 0.26f, 0.34f * opacity);
+    const nxui::Vec2 offsets[8] = {
+        {-halo, 0.f}, {halo, 0.f}, {0.f, -halo}, {0.f, halo},
+        {-halo, -halo}, {halo, -halo}, {-halo, halo}, {halo, halo}};
+    for (const nxui::Vec2& off : offsets)
+        ren.drawText(title, {pos.x + off.x, pos.y + off.y}, font, shadow, textScale);
+    ren.drawText(title, {pos.x, pos.y + halo * 0.7f}, font,
+                 nxui::Color(0.04f, 0.14f, 0.24f, 0.30f * opacity), textScale);
+    ren.drawText(title, pos, font, nxui::Color::white().withAlpha(0.98f * opacity), textScale);
+}
+
+struct FittedTitle {
+    float width = 0.f;
+    float height = 0.f;
+    float scale = 1.f;
+};
+
+FittedTitle measureTitle(nxui::Font* font, const std::string& title, float room,
+                         float preferredScale, float minScale) {
+    FittedTitle out;
+    const nxui::Vec2 measured = font->measure(title);
+    out.scale = preferredScale;
+    if (measured.x > 0.f)
+        out.scale = std::min(out.scale, room / measured.x);
+    out.scale = std::max(minScale, out.scale);
+    out.width = measured.x * out.scale;
+    out.height = measured.y * out.scale;
+    return out;
+}
+
+void drawNineGrid(nxui::Renderer& ren, const nxui::Rect& shell, const nxui::Color& accent,
+                  float scale, float opacity) {
+    const float cell = std::min(shell.width, shell.height) * 0.185f;
+    const float gap = cell * 0.18f;
+    const float gridSize = cell * 3.f + gap * 2.f;
+    const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
+    const float gridY = shell.y + (shell.height - gridSize) * 0.5f;
+    for (int i = 0; i < 9; ++i) {
+        const int col = i % 3;
+        const int row = i / 3;
+        const nxui::Rect cellRect{gridX + col * (cell + gap),
+                                  gridY + row * (cell + gap), cell, cell};
+        ren.drawRoundedRect({cellRect.x, cellRect.y + 1.8f * scale,
+                             cellRect.width, cellRect.height},
+                            nxui::Color(0.05f, 0.08f, 0.10f, 0.16f * opacity),
+                            cell * 0.20f);
+        const float variation = 0.92f + 0.035f * static_cast<float>((i + row) % 3);
+        nxui::Color cellColor(
+            std::min(1.f, accent.r * variation),
+            std::min(1.f, accent.g * variation),
+            std::min(1.f, accent.b * variation),
+            0.94f * opacity);
+        ren.drawRoundedRect(cellRect, cellColor, cell * 0.20f);
+        ren.drawRoundedRect({cellRect.x + cell * 0.10f,
+                             cellRect.y + cell * 0.08f,
+                             cellRect.width * 0.80f,
+                             std::max(1.f, cellRect.height * 0.13f)},
+                            nxui::Color::white().withAlpha(0.18f * opacity),
+                            cell * 0.08f);
+    }
+}
+
+void drawEmptyGlyph(nxui::Renderer& ren, const nxui::Rect& shell, const nxui::Color& accent,
+                    float opacity) {
+    const float cell = std::min(shell.width, shell.height) * 0.16f;
+    const float gap = cell * 0.22f;
+    const float gridSize = cell * 2.f + gap;
+    const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
+    const float gridY = shell.y + (shell.height - gridSize) * 0.52f;
+    for (int i = 0; i < 4; ++i) {
+        const int col = i % 2;
+        const int row = i / 2;
+        const nxui::Rect cellRect{gridX + col * (cell + gap),
+                                  gridY + row * (cell + gap), cell, cell};
+        ren.drawRoundedRect(cellRect, accent.withAlpha(0.55f * opacity), cell * 0.22f);
+    }
+}
+
+void drawTopCap(nxui::Renderer& ren, const nxui::Rect& inner, float innerRadius,
+                const nxui::Color& accent, float sliceH, float opacity) {
+    ren.pushClipRect({inner.x, inner.y, inner.width, sliceH});
+    ren.drawRoundedRect(inner, accent.withAlpha(0.78f * opacity), innerRadius);
+    ren.popClipRect();
+    const float highlightH = std::max(2.f, sliceH * 0.45f);
+    ren.pushClipRect({inner.x, inner.y, inner.width, highlightH});
+    ren.drawRoundedRect(inner, nxui::Color::white().withAlpha(0.22f * opacity), innerRadius);
+    ren.popClipRect();
+}
+
+void drawBottomBand(nxui::Renderer& ren, const nxui::Rect& inner, float innerRadius,
+                    const nxui::Color& accent, float sliceH, float opacity) {
+    const float y = inner.bottom() - sliceH;
+    ren.pushClipRect({inner.x, y, inner.width, sliceH});
+    ren.drawRoundedRect(inner, accent.withAlpha(0.82f * opacity), innerRadius);
+    ren.popClipRect();
+    const float highlightH = std::max(2.f, sliceH * 0.40f);
+    ren.pushClipRect({inner.x, y, inner.width, highlightH});
+    ren.drawRoundedRect(inner, nxui::Color::white().withAlpha(0.18f * opacity), innerRadius);
+    ren.popClipRect();
+}
+
+void drawFocus(nxui::Renderer& ren, const nxui::Rect& shell, float shellRadius,
+               const nxui::Color& accent, float scale, float opacity) {
+    ren.drawRoundedRectOutline(shell.expanded(2.f * scale),
+                               accent.withAlpha(0.50f * opacity),
+                               shellRadius + 2.f * scale, 2.f * scale);
+}
+
+void drawCoverPlaceholder(nxui::Renderer& ren, const nxui::Rect& photo,
+                          const nxui::Color& accent, float radius, float opacity) {
+    ren.drawRoundedRect(photo, nxui::Color(0.08f, 0.10f, 0.13f, 0.88f * opacity), radius);
+    ren.drawRoundedRect(photo, accent.withAlpha(0.28f * opacity), radius);
+    const nxui::Rect screen = photo.shrunk(photo.width * 0.14f);
+    ren.drawRoundedRect(screen, nxui::Color(0.18f, 0.22f, 0.28f, 0.90f * opacity),
+                        std::max(4.f, radius * 0.45f));
+}
+
+void drawCoverPhoto(nxui::Renderer& ren, const nxui::Rect& photo, float radius,
+                    const nxui::Texture* cover, const nxui::Color& accent,
+                    float opacity) {
+    if (cover)
+        ren.drawTextureRounded(cover, photo, radius,
+                               nxui::Color::white().withAlpha(opacity));
+    else
+        drawCoverPlaceholder(ren, photo, accent, radius, opacity);
+}
+
+nxui::Rect coverPhotoRect(const nxui::Rect& host, float topPad, float bottomPad) {
+    float side = std::min(host.width, host.height) * 0.62f;
+    side = std::min(side, std::max(18.f, host.height - topPad - bottomPad));
+    side = std::max(18.f, side);
+    return {host.x + (host.width - side) * 0.5f, host.y + topPad, side, side};
+}
+
+} // namespace
+
+void drawFolderStyle(const FolderStyleDrawArgs& args) {
+    if (!args.renderer)
+        return;
+
+    nxui::Renderer& ren = *args.renderer;
+    const nxui::Rect& shell = args.bounds;
+    const float s = std::max(0.35f, args.scale);
+    const float opacity = args.opacity;
+    const nxui::Color& accent = args.accent;
+    const float shellRadius = args.radius;
+    const nxui::Rect inner = shell.shrunk(1.f * s);
+    const float innerRadius = std::max(8.f, shellRadius - 1.f * s);
+    const float sliceH = std::max(4.f, shell.height * 0.09f);
+    const ThemeShell theme = themeShell(args.themeMode, opacity);
+    const int style = std::clamp(args.styleIndex, 0, kFolderStyleCount - 1);
+    const bool named = args.drawName && args.font && args.title && !args.title->empty();
+    const nxui::Texture* cover = (args.cover && args.cover->valid()) ? args.cover : nullptr;
+    const bool useCover = folderShouldShowCover(style, args.showCover) &&
+                          (cover || args.schematicPlaceholder);
+
+    auto drawCenteredName = [&](bool halo, float preferred, float minScale, float yBias) {
+        if (!named)
+            return;
+        const FittedTitle fit = measureTitle(args.font, *args.title,
+                                             std::max(8.f, shell.width - 18.f * s),
+                                             preferred * s, minScale * s);
+        const nxui::Vec2 pos{shell.x + (shell.width - fit.width) * 0.5f,
+                             shell.y + (shell.height - fit.height) * yBias};
+        if (halo)
+            drawHaloTitle(ren, args.font, *args.title, pos, fit.scale, s, opacity);
+        else
+            ren.drawText(*args.title, pos, args.font, theme.title, fit.scale);
+    };
+
+    auto drawCoverName = [&](const nxui::Rect& host, const nxui::Rect& photo, bool halo) {
+        if (!named)
+            return;
+        const FittedTitle fit = measureTitle(args.font, *args.title,
+                                             std::max(8.f, host.width - 16.f * s),
+                                             0.78f * s, 0.38f * s);
+        const float nameY = std::min(photo.bottom() + 4.f * s,
+                                     host.bottom() - fit.height - 6.f * s);
+        const nxui::Vec2 pos{host.x + (host.width - fit.width) * 0.5f, nameY};
+        if (halo)
+            drawHaloTitle(ren, args.font, *args.title, pos, fit.scale, s, opacity);
+        else
+            ren.drawText(*args.title, pos, args.font, theme.title, fit.scale);
+    };
+
+    if (style == kFolderStyleClassic) {
+        const nxui::Color plateWash =
+            accent.withAlpha((theme.light ? 0.10f : 0.14f) * opacity);
+        ren.drawRoundedRect(shell, theme.fill, shellRadius);
+        ren.drawRoundedRect(shell, plateWash, shellRadius);
+        ren.drawRoundedRectOutline(shell.shrunk(1.f * s), theme.outline,
+                                   std::max(8.f, shellRadius - 1.f * s), 1.5f * s);
+        drawNineGrid(ren, shell, accent, s, opacity);
+        if (named) {
+            const FittedTitle fit = measureTitle(args.font, *args.title,
+                                                 std::max(8.f, shell.width - 6.f * s),
+                                                 1.05f * s, 0.38f * s);
+            const nxui::Vec2 pos{shell.x + (shell.width - fit.width) * 0.5f,
+                                 shell.y + (shell.height - fit.height) * 0.5f};
+            drawHaloTitle(ren, args.font, *args.title, pos, fit.scale, s, opacity);
+        }
+        if (args.focused)
+            drawFocus(ren, shell, shellRadius, accent, s, opacity);
+        return;
+    }
+
+    if (style == kFolderStyleManila) {
+        const float tabW = std::max(18.f, shell.width * 0.28f);
+        const nxui::Rect flap{shell.x + 8.f * s, shell.y,
+                              shell.width - 16.f * s, shell.height * 0.30f};
+        const nxui::Rect tab{shell.right() - 10.f * s - tabW, shell.y,
+                             tabW, shell.height * 0.20f};
+        const nxui::Rect body{shell.x, shell.y + shell.height * 0.12f,
+                              shell.width, shell.height * 0.88f};
+        const float bodyRadius = std::max(10.f, shellRadius * 0.92f);
+        ren.drawRoundedRect(flap, accent.withAlpha(0.42f * opacity), 8.f * s);
+        ren.drawRoundedRect(tab, accent.withAlpha(0.92f * opacity), 6.f * s);
+        ren.drawRoundedRect(body, theme.fill, bodyRadius);
+        ren.drawRoundedRect(body, accent.withAlpha((theme.light ? 0.08f : 0.12f) * opacity),
+                            bodyRadius);
+        ren.drawRoundedRectOutline(body.shrunk(1.f * s), theme.outline,
+                                   std::max(8.f, bodyRadius - 1.f * s), 1.5f * s);
+        if (useCover) {
+            const nxui::Rect host = body.shrunk(6.f * s);
+            const float bottomPad = named ? 20.f * s : 8.f * s;
+            const nxui::Rect photo = coverPhotoRect(host, 4.f * s, bottomPad);
+            drawCoverPhoto(ren, photo, std::max(6.f, photo.width * 0.16f),
+                           cover, accent, opacity);
+            drawCoverName(body, photo, true);
+        } else if (named) {
+            const FittedTitle fit = measureTitle(args.font, *args.title,
+                                                 std::max(8.f, body.width - 18.f * s),
+                                                 0.92f * s, 0.40f * s);
+            const nxui::Vec2 pos{body.x + (body.width - fit.width) * 0.5f,
+                                 body.y + (body.height - fit.height) * 0.52f};
+            ren.drawText(*args.title, pos, args.font, theme.title, fit.scale);
+        } else if (!args.schematicPlaceholder) {
+            drawEmptyGlyph(ren, body, accent, opacity);
+        }
+        if (args.focused)
+            drawFocus(ren, shell, shellRadius, accent, s, opacity);
+        return;
+    }
+
+    ren.drawRoundedRect(shell, theme.fill, shellRadius);
+    ren.drawRoundedRect(shell, accent.withAlpha((theme.light ? 0.10f : 0.14f) * opacity),
+                        shellRadius);
+
+    if (style == kFolderStyleSimple)
+        drawTopCap(ren, inner, innerRadius, accent, sliceH, opacity);
+    else if (style == kFolderStyleTab) {
+        const float tabW = std::max(14.f, inner.width * 0.34f);
+        const float tabH = std::max(6.f, inner.height * 0.12f);
+        ren.pushClipRect({inner.x, inner.y, tabW, tabH});
+        ren.drawRoundedRect(inner, accent.withAlpha(0.82f * opacity), innerRadius);
+        ren.popClipRect();
+        const float highlightH = std::max(2.f, tabH * 0.40f);
+        ren.pushClipRect({inner.x, inner.y, tabW, highlightH});
+        ren.drawRoundedRect(inner, nxui::Color::white().withAlpha(0.22f * opacity), innerRadius);
+        ren.popClipRect();
+    } else if (style == kFolderStyleLabel)
+        drawBottomBand(ren, inner, innerRadius, accent, sliceH, opacity);
+    else if (style == kFolderStyleRing)
+        ren.drawRoundedRectOutline(inner, accent.withAlpha(0.90f * opacity),
+                                   innerRadius, std::max(2.5f, 3.6f * s));
+
+    if (style != kFolderStyleRing)
+        ren.drawRoundedRectOutline(inner, theme.outline, innerRadius, 1.5f * s);
+
+    if (useCover) {
+        const float topPad = (style == kFolderStyleSimple || style == kFolderStyleTab)
+            ? sliceH + 6.f * s : 6.f * s;
+        const float bottomPad = style == kFolderStyleLabel
+            ? sliceH + (named ? 18.f * s : 8.f * s)
+            : (named ? 20.f * s : 8.f * s);
+        const nxui::Rect photo = coverPhotoRect(inner, topPad, bottomPad);
+        drawCoverPhoto(ren, photo, std::max(6.f, photo.width * 0.16f),
+                       cover, accent, opacity);
+        if (style == kFolderStyleLabel && named) {
+            const FittedTitle fit = measureTitle(args.font, *args.title,
+                                                 std::max(8.f, shell.width - 18.f * s),
+                                                 0.78f * s, 0.38f * s);
+            const float nameY = std::min(photo.bottom() + 3.f * s,
+                                         shell.bottom() - sliceH - fit.height - 3.f * s);
+            const nxui::Vec2 pos{shell.x + (shell.width - fit.width) * 0.5f, nameY};
+            ren.drawText(*args.title, pos, args.font, theme.title, fit.scale);
+        } else {
+            drawCoverName(shell, photo, true);
+        }
+        if (args.focused)
+            drawFocus(ren, shell, shellRadius, accent, s, opacity);
+        return;
+    }
+
+    if (style == kFolderStyleLabel && named) {
+        const FittedTitle fit = measureTitle(args.font, *args.title,
+                                             std::max(8.f, shell.width - 18.f * s),
+                                             0.92f * s, 0.40f * s);
+        const float nameY = shell.y + (shell.height - sliceH - fit.height) * 0.50f;
+        const nxui::Vec2 pos{shell.x + (shell.width - fit.width) * 0.5f, nameY};
+        ren.drawText(*args.title, pos, args.font, theme.title, fit.scale);
+    } else if (named) {
+        drawCenteredName(false, 0.92f, 0.40f, 0.52f);
+    } else if (!args.schematicPlaceholder &&
+               (style == kFolderStyleSimple || style == kFolderStyleMinimal ||
+                style == kFolderStyleTab || style == kFolderStyleRing)) {
+        drawEmptyGlyph(ren, shell, accent, opacity);
+    }
+
+    if (args.focused)
+        drawFocus(ren, shell, shellRadius, accent, s, opacity);
+}
+
+} // namespace switchu::folders

--- a/projects/menu/src/widgets/FolderStyleDraw.hpp
+++ b/projects/menu/src/widgets/FolderStyleDraw.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <nxui/core/Types.hpp>
+#include <nxui/Theme.hpp>
+#include <cstdint>
+#include <string>
+
+namespace nxui {
+class Font;
+class Renderer;
+class Texture;
+}
+
+namespace switchu::folders {
+
+struct FolderStyleDrawArgs {
+    nxui::Renderer* renderer = nullptr;
+    nxui::Rect bounds{};
+    float radius = 18.f;
+    float scale = 1.f;
+    float opacity = 1.f;
+    int styleIndex = 0;
+    nxui::Color accent{};
+    nxui::ThemeMode themeMode = nxui::ThemeMode::Dark;
+    nxui::Font* font = nullptr;
+    const std::string* title = nullptr;
+    nxui::Texture* cover = nullptr;
+    bool showCover = false;
+    bool focused = false;
+    bool drawName = true;
+    bool schematicPlaceholder = false;
+};
+
+void drawFolderStyle(const FolderStyleDrawArgs& args);
+
+} // namespace switchu::folders

--- a/projects/menu/src/widgets/GlossyIcon.cpp
+++ b/projects/menu/src/widgets/GlossyIcon.cpp
@@ -1,5 +1,6 @@
 #include "GlossyIcon.hpp"
 #include "FolderPalette.hpp"
+#include "core/FolderStore.hpp"
 #include "BatteryDrawing.hpp"
 #include "core/DebugLog.hpp"
 #include <nxui/core/Renderer.hpp>
@@ -936,91 +937,170 @@ void GlossyIcon::onContentRender(nxui::Renderer& ren) {
 
     if (m_entryKind == GridEntryKind::Folder) {
         nxui::Color accent = switchu::folders::colorForIndex(m_folderColorIndex);
+        const bool classic = m_folderStyleIndex == switchu::folders::kFolderStyleClassic;
 
-        const float inset = 10.f * s;
-        const nxui::Rect shell = r.shrunk(inset);
-        const float shellRadius = std::max(12.f, rad - 2.f);
-        ren.drawRoundedRect({shell.x, shell.y + 4.f * s, shell.width, shell.height},
-                            nxui::Color(0.03f, 0.05f, 0.08f, 0.30f * m_opacity),
-                            shellRadius);
-        ren.drawRoundedRect(shell,
-                            nxui::Color(0.94f, 0.97f, 0.96f, 0.96f * m_opacity),
-                            shellRadius);
-        ren.drawRoundedRect(shell.shrunk(3.f * s),
-                            nxui::Color(0.72f, 0.78f, 0.79f, 0.28f * m_opacity),
-                            std::max(8.f, shellRadius - 3.f * s));
-        ren.drawRoundedRectOutline(shell.shrunk(1.f * s),
-                                   nxui::Color::white().withAlpha(0.92f * m_opacity),
-                                   std::max(8.f, shellRadius - 1.f * s), 2.f * s);
+        if (classic) {
+            const float inset = 10.f * s;
+            const nxui::Rect shell = r.shrunk(inset);
+            const float shellRadius = std::max(12.f, rad - 2.f);
+            ren.drawRoundedRect({shell.x, shell.y + 4.f * s, shell.width, shell.height},
+                                nxui::Color(0.03f, 0.05f, 0.08f, 0.30f * m_opacity),
+                                shellRadius);
+            ren.drawRoundedRect(shell,
+                                nxui::Color(0.94f, 0.97f, 0.96f, 0.96f * m_opacity),
+                                shellRadius);
+            ren.drawRoundedRect(shell.shrunk(3.f * s),
+                                nxui::Color(0.72f, 0.78f, 0.79f, 0.28f * m_opacity),
+                                std::max(8.f, shellRadius - 3.f * s));
+            ren.drawRoundedRectOutline(shell.shrunk(1.f * s),
+                                       nxui::Color::white().withAlpha(0.92f * m_opacity),
+                                       std::max(8.f, shellRadius - 1.f * s), 2.f * s);
 
-        const bool named = m_font && !m_title.empty();
+            const bool named = m_font && !m_title.empty();
+            const float cell = std::min(shell.width, shell.height) * 0.185f;
+            const float gap = cell * 0.18f;
+            const float gridSize = cell * 3.f + gap * 2.f;
+            const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
+            const float gridY = shell.y + (shell.height - gridSize) * 0.5f;
+            for (int i = 0; i < 9; ++i) {
+                const int col = i % 3;
+                const int row = i / 3;
+                const nxui::Rect cellRect{gridX + col * (cell + gap),
+                                          gridY + row * (cell + gap), cell, cell};
+                ren.drawRoundedRect({cellRect.x, cellRect.y + 1.8f * s,
+                                     cellRect.width, cellRect.height},
+                                    nxui::Color(0.05f, 0.08f, 0.10f,
+                                                0.16f * m_opacity),
+                                    cell * 0.20f);
+                const float variation = 0.92f + 0.035f * static_cast<float>((i + row) % 3);
+                nxui::Color cellColor(
+                    std::min(1.f, accent.r * variation),
+                    std::min(1.f, accent.g * variation),
+                    std::min(1.f, accent.b * variation),
+                    0.94f * m_opacity);
+                ren.drawRoundedRect(cellRect, cellColor, cell * 0.20f);
+                ren.drawRoundedRect({cellRect.x + cell * 0.10f,
+                                     cellRect.y + cell * 0.08f,
+                                     cellRect.width * 0.80f,
+                                     std::max(1.f, cellRect.height * 0.13f)},
+                                    nxui::Color::white().withAlpha(0.18f * m_opacity),
+                                    cell * 0.08f);
+            }
 
-        const float cell = std::min(shell.width, shell.height) * 0.185f;
-        const float gap = cell * 0.18f;
-        const float gridSize = cell * 3.f + gap * 2.f;
-        const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
-        const float gridY = shell.y + (shell.height - gridSize) * 0.5f;
-        for (int i = 0; i < 9; ++i) {
-            const int col = i % 3;
-            const int row = i / 3;
-            const nxui::Rect cellRect{gridX + col * (cell + gap),
-                                      gridY + row * (cell + gap), cell, cell};
-            ren.drawRoundedRect({cellRect.x, cellRect.y + 1.8f * s,
-                                 cellRect.width, cellRect.height},
-                                nxui::Color(0.05f, 0.08f, 0.10f,
-                                            0.16f * m_opacity),
-                                cell * 0.20f);
-            const float variation = 0.92f + 0.035f * static_cast<float>((i + row) % 3);
-            nxui::Color cellColor(
-                std::min(1.f, accent.r * variation),
-                std::min(1.f, accent.g * variation),
-                std::min(1.f, accent.b * variation),
-                0.94f * m_opacity);
-            ren.drawRoundedRect(cellRect, cellColor, cell * 0.20f);
-            ren.drawRoundedRect({cellRect.x + cell * 0.10f,
-                                 cellRect.y + cell * 0.08f,
-                                 cellRect.width * 0.80f,
-                                 std::max(1.f, cellRect.height * 0.13f)},
-                                nxui::Color::white().withAlpha(0.18f * m_opacity),
-                                cell * 0.08f);
+            if (named) {
+                const nxui::Vec2 measured = m_font->measure(m_title);
+                const float room = std::max(8.f, shell.width - 6.f * s);
+                float textScale = 1.05f * s;
+                if (measured.x > 0.f)
+                    textScale = std::min(textScale, room / measured.x);
+                textScale = std::max(0.38f * s, textScale);
+
+                const float textW = measured.x * textScale;
+                const float textH = measured.y * textScale;
+                const nxui::Vec2 textPos{shell.x + (shell.width - textW) * 0.5f,
+                                         shell.y + (shell.height - textH) * 0.5f};
+
+                const float halo = std::max(1.f, 1.5f * s);
+                const nxui::Color shadow(0.05f, 0.16f, 0.26f, 0.34f * m_opacity);
+                const nxui::Vec2 offsets[8] = {
+                    {-halo, 0.f}, {halo, 0.f}, {0.f, -halo}, {0.f, halo},
+                    {-halo, -halo}, {halo, -halo}, {-halo, halo}, {halo, halo}};
+                for (const nxui::Vec2& off : offsets)
+                    ren.drawText(m_title, {textPos.x + off.x, textPos.y + off.y},
+                                 m_font, shadow, textScale);
+
+                ren.drawText(m_title,
+                             {textPos.x, textPos.y + halo * 0.7f},
+                             m_font,
+                             nxui::Color(0.04f, 0.14f, 0.24f, 0.30f * m_opacity),
+                             textScale);
+
+                ren.drawText(m_title, textPos, m_font,
+                             nxui::Color::white().withAlpha(0.98f * m_opacity),
+                             textScale);
+            }
+
+            if (m_focused) {
+                ren.drawRoundedRectOutline(shell.expanded(2.f * s),
+                                           accent.withAlpha(0.42f * m_opacity),
+                                           shellRadius + 2.f * s, 2.f * s);
+            }
+            return;
         }
 
+        // Glass style — translucent shell with an accent slice and contrast band.
+        const float inset = 8.f * s;
+        const nxui::Rect shell = r.shrunk(inset);
+        const float shellRadius = std::max(12.f, rad - 2.f);
+
+        ren.drawRoundedRect(shell,
+                            nxui::Color(0.04f, 0.07f, 0.11f, 0.42f * m_opacity),
+                            shellRadius);
+        ren.drawRoundedRect(shell,
+                            accent.withAlpha(0.16f * m_opacity),
+                            shellRadius);
+        ren.drawRoundedRectOutline(shell.shrunk(1.f * s),
+                                   nxui::Color::white().withAlpha(0.38f * m_opacity),
+                                   std::max(8.f, shellRadius - 1.f * s), 1.5f * s);
+
+        const float sliceH = std::max(4.f, shell.height * 0.09f);
+        ren.drawRoundedRect({shell.x + 3.f * s, shell.y + 3.f * s,
+                             shell.width - 6.f * s, sliceH},
+                            accent.withAlpha(0.78f * m_opacity),
+                            sliceH * 0.45f);
+        ren.drawRoundedRect({shell.x + 3.f * s, shell.y + 3.f * s,
+                             shell.width - 6.f * s, sliceH * 0.45f},
+                            nxui::Color::white().withAlpha(0.22f * m_opacity),
+                            sliceH * 0.35f);
+
+        const bool named = m_font && !m_title.empty();
         if (named) {
             const nxui::Vec2 measured = m_font->measure(m_title);
-            const float room = std::max(8.f, shell.width - 6.f * s);
-            float textScale = 1.05f * s;
+            const float room = std::max(8.f, shell.width - 18.f * s);
+            float textScale = 0.92f * s;
             if (measured.x > 0.f)
                 textScale = std::min(textScale, room / measured.x);
-            textScale = std::max(0.38f * s, textScale);
+            textScale = std::max(0.40f * s, textScale);
 
             const float textW = measured.x * textScale;
             const float textH = measured.y * textScale;
             const nxui::Vec2 textPos{shell.x + (shell.width - textW) * 0.5f,
-                                     shell.y + (shell.height - textH) * 0.5f};
+                                     shell.y + (shell.height - textH) * 0.52f};
 
-            const float halo = std::max(1.f, 1.5f * s);
-            const nxui::Color shadow(0.05f, 0.16f, 0.26f, 0.34f * m_opacity);
-            const nxui::Vec2 offsets[8] = {
-                {-halo, 0.f}, {halo, 0.f}, {0.f, -halo}, {0.f, halo},
-                {-halo, -halo}, {halo, -halo}, {-halo, halo}, {halo, halo}};
-            for (const nxui::Vec2& off : offsets)
-                ren.drawText(m_title, {textPos.x + off.x, textPos.y + off.y},
-                             m_font, shadow, textScale);
-
-            ren.drawText(m_title,
-                         {textPos.x, textPos.y + halo * 0.7f},
-                         m_font,
-                         nxui::Color(0.04f, 0.14f, 0.24f, 0.30f * m_opacity),
-                         textScale);
+            const float bandPadX = 10.f * s;
+            const float bandPadY = 6.f * s;
+            const nxui::Rect band{
+                std::max(shell.x + 4.f * s, textPos.x - bandPadX),
+                textPos.y - bandPadY,
+                std::min(shell.width - 8.f * s, textW + bandPadX * 2.f),
+                textH + bandPadY * 2.f};
+            ren.drawRoundedRect(band,
+                                nxui::Color(0.02f, 0.04f, 0.08f, 0.62f * m_opacity),
+                                std::max(6.f, band.height * 0.35f));
 
             ren.drawText(m_title, textPos, m_font,
                          nxui::Color::white().withAlpha(0.98f * m_opacity),
                          textScale);
+        } else {
+            const float cell = std::min(shell.width, shell.height) * 0.16f;
+            const float gap = cell * 0.22f;
+            const float gridSize = cell * 2.f + gap;
+            const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
+            const float gridY = shell.y + (shell.height - gridSize) * 0.52f;
+            for (int i = 0; i < 4; ++i) {
+                const int col = i % 2;
+                const int row = i / 2;
+                const nxui::Rect cellRect{gridX + col * (cell + gap),
+                                          gridY + row * (cell + gap), cell, cell};
+                ren.drawRoundedRect(cellRect,
+                                    accent.withAlpha(0.55f * m_opacity),
+                                    cell * 0.22f);
+            }
         }
 
         if (m_focused) {
             ren.drawRoundedRectOutline(shell.expanded(2.f * s),
-                                       accent.withAlpha(0.42f * m_opacity),
+                                       accent.withAlpha(0.50f * m_opacity),
                                        shellRadius + 2.f * s, 2.f * s);
         }
         return;

--- a/projects/menu/src/widgets/GlossyIcon.cpp
+++ b/projects/menu/src/widgets/GlossyIcon.cpp
@@ -471,6 +471,11 @@ void GlossyIcon::setWidgetGameTextures(std::uint64_t titleId,
 
 void GlossyIcon::copyWidgetPresentationFrom(GlossyIcon& source) {
     m_entryKind = source.m_entryKind;
+    m_folderPreviewCount = source.m_folderPreviewCount;
+    m_folderVisualSeed = source.m_folderVisualSeed;
+    m_folderColorIndex = source.m_folderColorIndex;
+    m_folderStyleIndex = source.m_folderStyleIndex;
+    m_themeMode = source.m_themeMode;
     m_widgetType = source.m_widgetType;
     m_widgetColumns = source.m_widgetColumns;
     m_widgetRows = source.m_widgetRows;
@@ -1028,19 +1033,26 @@ void GlossyIcon::onContentRender(nxui::Renderer& ren) {
             return;
         }
 
-        // Glass style — translucent shell with an accent slice and contrast band.
+        // Simple style — solid tile that follows the active theme light/dark mode.
+        const bool lightTheme = m_themeMode == nxui::ThemeMode::Light;
         const float inset = 8.f * s;
         const nxui::Rect shell = r.shrunk(inset);
         const float shellRadius = std::max(12.f, rad - 2.f);
 
-        ren.drawRoundedRect(shell,
-                            nxui::Color(0.04f, 0.07f, 0.11f, 0.42f * m_opacity),
+        const nxui::Color shellFill = lightTheme
+            ? nxui::Color(0.94f, 0.96f, 0.97f, 0.96f * m_opacity)
+            : nxui::Color(0.10f, 0.13f, 0.17f, 0.92f * m_opacity);
+        const nxui::Color shellOutline = lightTheme
+            ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * m_opacity)
+            : nxui::Color::white().withAlpha(0.28f * m_opacity);
+        const nxui::Color titleColor = lightTheme
+            ? nxui::Color(0.08f, 0.12f, 0.16f, 0.96f * m_opacity)
+            : nxui::Color::white().withAlpha(0.98f * m_opacity);
+
+        ren.drawRoundedRect(shell, shellFill, shellRadius);
+        ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * m_opacity),
                             shellRadius);
-        ren.drawRoundedRect(shell,
-                            accent.withAlpha(0.16f * m_opacity),
-                            shellRadius);
-        ren.drawRoundedRectOutline(shell.shrunk(1.f * s),
-                                   nxui::Color::white().withAlpha(0.38f * m_opacity),
+        ren.drawRoundedRectOutline(shell.shrunk(1.f * s), shellOutline,
                                    std::max(8.f, shellRadius - 1.f * s), 1.5f * s);
 
         const float sliceH = std::max(4.f, shell.height * 0.09f);
@@ -1067,20 +1079,7 @@ void GlossyIcon::onContentRender(nxui::Renderer& ren) {
             const nxui::Vec2 textPos{shell.x + (shell.width - textW) * 0.5f,
                                      shell.y + (shell.height - textH) * 0.52f};
 
-            const float bandPadX = 10.f * s;
-            const float bandPadY = 6.f * s;
-            const nxui::Rect band{
-                std::max(shell.x + 4.f * s, textPos.x - bandPadX),
-                textPos.y - bandPadY,
-                std::min(shell.width - 8.f * s, textW + bandPadX * 2.f),
-                textH + bandPadY * 2.f};
-            ren.drawRoundedRect(band,
-                                nxui::Color(0.02f, 0.04f, 0.08f, 0.62f * m_opacity),
-                                std::max(6.f, band.height * 0.35f));
-
-            ren.drawText(m_title, textPos, m_font,
-                         nxui::Color::white().withAlpha(0.98f * m_opacity),
-                         textScale);
+            ren.drawText(m_title, textPos, m_font, titleColor, textScale);
         } else {
             const float cell = std::min(shell.width, shell.height) * 0.16f;
             const float gap = cell * 0.22f;

--- a/projects/menu/src/widgets/GlossyIcon.cpp
+++ b/projects/menu/src/widgets/GlossyIcon.cpp
@@ -1049,21 +1049,25 @@ void GlossyIcon::onContentRender(nxui::Renderer& ren) {
             ? nxui::Color(0.08f, 0.12f, 0.16f, 0.96f * m_opacity)
             : nxui::Color::white().withAlpha(0.98f * m_opacity);
 
+        const nxui::Rect inner = shell.shrunk(1.f * s);
+        const float innerRadius = std::max(8.f, shellRadius - 1.f * s);
+        const float sliceH = std::max(4.f, shell.height * 0.09f);
+
         ren.drawRoundedRect(shell, shellFill, shellRadius);
         ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * m_opacity),
                             shellRadius);
-        ren.drawRoundedRectOutline(shell.shrunk(1.f * s), shellOutline,
-                                   std::max(8.f, shellRadius - 1.f * s), 1.5f * s);
 
-        const float sliceH = std::max(4.f, shell.height * 0.09f);
-        ren.drawRoundedRect({shell.x + 3.f * s, shell.y + 3.f * s,
-                             shell.width - 6.f * s, sliceH},
-                            accent.withAlpha(0.78f * m_opacity),
-                            sliceH * 0.45f);
-        ren.drawRoundedRect({shell.x + 3.f * s, shell.y + 3.f * s,
-                             shell.width - 6.f * s, sliceH * 0.45f},
-                            nxui::Color::white().withAlpha(0.22f * m_opacity),
-                            sliceH * 0.35f);
+        // Full-width top cap clipped to the shell so the corners follow the
+        // tile radius instead of overlapping the outline.
+        ren.pushClipRect({inner.x, inner.y, inner.width, sliceH});
+        ren.drawRoundedRect(inner, accent.withAlpha(0.78f * m_opacity), innerRadius);
+        ren.popClipRect();
+        const float highlightH = std::max(2.f, sliceH * 0.45f);
+        ren.pushClipRect({inner.x, inner.y, inner.width, highlightH});
+        ren.drawRoundedRect(inner, nxui::Color::white().withAlpha(0.22f * m_opacity), innerRadius);
+        ren.popClipRect();
+
+        ren.drawRoundedRectOutline(inner, shellOutline, innerRadius, 1.5f * s);
 
         const bool named = m_font && !m_title.empty();
         if (named) {

--- a/projects/menu/src/widgets/GlossyIcon.cpp
+++ b/projects/menu/src/widgets/GlossyIcon.cpp
@@ -1,5 +1,6 @@
 #include "GlossyIcon.hpp"
 #include "FolderPalette.hpp"
+#include "FolderStyleDraw.hpp"
 #include "core/FolderStore.hpp"
 #include "BatteryDrawing.hpp"
 #include "core/DebugLog.hpp"
@@ -475,6 +476,9 @@ void GlossyIcon::copyWidgetPresentationFrom(GlossyIcon& source) {
     m_folderVisualSeed = source.m_folderVisualSeed;
     m_folderColorIndex = source.m_folderColorIndex;
     m_folderStyleIndex = source.m_folderStyleIndex;
+    m_folderShowCover = source.m_folderShowCover;
+    m_folderCover = source.m_folderCover;
+    m_folderCoverTitleId = source.m_folderCoverTitleId;
     m_themeMode = source.m_themeMode;
     m_widgetType = source.m_widgetType;
     m_widgetColumns = source.m_widgetColumns;
@@ -941,171 +945,25 @@ void GlossyIcon::onContentRender(nxui::Renderer& ren) {
     }
 
     if (m_entryKind == GridEntryKind::Folder) {
-        nxui::Color accent = switchu::folders::colorForIndex(m_folderColorIndex);
-        const bool classic = m_folderStyleIndex == switchu::folders::kFolderStyleClassic;
-
-        if (classic) {
-            const float inset = 10.f * s;
-            const nxui::Rect shell = r.shrunk(inset);
-            const float shellRadius = std::max(12.f, rad - 2.f);
-            ren.drawRoundedRect({shell.x, shell.y + 4.f * s, shell.width, shell.height},
-                                nxui::Color(0.03f, 0.05f, 0.08f, 0.30f * m_opacity),
-                                shellRadius);
-            ren.drawRoundedRect(shell,
-                                nxui::Color(0.94f, 0.97f, 0.96f, 0.96f * m_opacity),
-                                shellRadius);
-            ren.drawRoundedRect(shell.shrunk(3.f * s),
-                                nxui::Color(0.72f, 0.78f, 0.79f, 0.28f * m_opacity),
-                                std::max(8.f, shellRadius - 3.f * s));
-            ren.drawRoundedRectOutline(shell.shrunk(1.f * s),
-                                       nxui::Color::white().withAlpha(0.92f * m_opacity),
-                                       std::max(8.f, shellRadius - 1.f * s), 2.f * s);
-
-            const bool named = m_font && !m_title.empty();
-            const float cell = std::min(shell.width, shell.height) * 0.185f;
-            const float gap = cell * 0.18f;
-            const float gridSize = cell * 3.f + gap * 2.f;
-            const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
-            const float gridY = shell.y + (shell.height - gridSize) * 0.5f;
-            for (int i = 0; i < 9; ++i) {
-                const int col = i % 3;
-                const int row = i / 3;
-                const nxui::Rect cellRect{gridX + col * (cell + gap),
-                                          gridY + row * (cell + gap), cell, cell};
-                ren.drawRoundedRect({cellRect.x, cellRect.y + 1.8f * s,
-                                     cellRect.width, cellRect.height},
-                                    nxui::Color(0.05f, 0.08f, 0.10f,
-                                                0.16f * m_opacity),
-                                    cell * 0.20f);
-                const float variation = 0.92f + 0.035f * static_cast<float>((i + row) % 3);
-                nxui::Color cellColor(
-                    std::min(1.f, accent.r * variation),
-                    std::min(1.f, accent.g * variation),
-                    std::min(1.f, accent.b * variation),
-                    0.94f * m_opacity);
-                ren.drawRoundedRect(cellRect, cellColor, cell * 0.20f);
-                ren.drawRoundedRect({cellRect.x + cell * 0.10f,
-                                     cellRect.y + cell * 0.08f,
-                                     cellRect.width * 0.80f,
-                                     std::max(1.f, cellRect.height * 0.13f)},
-                                    nxui::Color::white().withAlpha(0.18f * m_opacity),
-                                    cell * 0.08f);
-            }
-
-            if (named) {
-                const nxui::Vec2 measured = m_font->measure(m_title);
-                const float room = std::max(8.f, shell.width - 6.f * s);
-                float textScale = 1.05f * s;
-                if (measured.x > 0.f)
-                    textScale = std::min(textScale, room / measured.x);
-                textScale = std::max(0.38f * s, textScale);
-
-                const float textW = measured.x * textScale;
-                const float textH = measured.y * textScale;
-                const nxui::Vec2 textPos{shell.x + (shell.width - textW) * 0.5f,
-                                         shell.y + (shell.height - textH) * 0.5f};
-
-                const float halo = std::max(1.f, 1.5f * s);
-                const nxui::Color shadow(0.05f, 0.16f, 0.26f, 0.34f * m_opacity);
-                const nxui::Vec2 offsets[8] = {
-                    {-halo, 0.f}, {halo, 0.f}, {0.f, -halo}, {0.f, halo},
-                    {-halo, -halo}, {halo, -halo}, {-halo, halo}, {halo, halo}};
-                for (const nxui::Vec2& off : offsets)
-                    ren.drawText(m_title, {textPos.x + off.x, textPos.y + off.y},
-                                 m_font, shadow, textScale);
-
-                ren.drawText(m_title,
-                             {textPos.x, textPos.y + halo * 0.7f},
-                             m_font,
-                             nxui::Color(0.04f, 0.14f, 0.24f, 0.30f * m_opacity),
-                             textScale);
-
-                ren.drawText(m_title, textPos, m_font,
-                             nxui::Color::white().withAlpha(0.98f * m_opacity),
-                             textScale);
-            }
-
-            if (m_focused) {
-                ren.drawRoundedRectOutline(shell.expanded(2.f * s),
-                                           accent.withAlpha(0.42f * m_opacity),
-                                           shellRadius + 2.f * s, 2.f * s);
-            }
-            return;
-        }
-
-        // Simple style — solid tile that follows the active theme light/dark mode.
-        const bool lightTheme = m_themeMode == nxui::ThemeMode::Light;
-        const float inset = 8.f * s;
-        const nxui::Rect shell = r.shrunk(inset);
-        const float shellRadius = std::max(12.f, rad - 2.f);
-
-        const nxui::Color shellFill = lightTheme
-            ? nxui::Color(0.94f, 0.96f, 0.97f, 0.96f * m_opacity)
-            : nxui::Color(0.10f, 0.13f, 0.17f, 0.92f * m_opacity);
-        const nxui::Color shellOutline = lightTheme
-            ? nxui::Color(0.12f, 0.16f, 0.20f, 0.18f * m_opacity)
-            : nxui::Color::white().withAlpha(0.28f * m_opacity);
-        const nxui::Color titleColor = lightTheme
-            ? nxui::Color(0.08f, 0.12f, 0.16f, 0.96f * m_opacity)
-            : nxui::Color::white().withAlpha(0.98f * m_opacity);
-
-        const nxui::Rect inner = shell.shrunk(1.f * s);
-        const float innerRadius = std::max(8.f, shellRadius - 1.f * s);
-        const float sliceH = std::max(4.f, shell.height * 0.09f);
-
-        ren.drawRoundedRect(shell, shellFill, shellRadius);
-        ren.drawRoundedRect(shell, accent.withAlpha((lightTheme ? 0.10f : 0.14f) * m_opacity),
-                            shellRadius);
-
-        // Full-width top cap clipped to the shell so the corners follow the
-        // tile radius instead of overlapping the outline.
-        ren.pushClipRect({inner.x, inner.y, inner.width, sliceH});
-        ren.drawRoundedRect(inner, accent.withAlpha(0.78f * m_opacity), innerRadius);
-        ren.popClipRect();
-        const float highlightH = std::max(2.f, sliceH * 0.45f);
-        ren.pushClipRect({inner.x, inner.y, inner.width, highlightH});
-        ren.drawRoundedRect(inner, nxui::Color::white().withAlpha(0.22f * m_opacity), innerRadius);
-        ren.popClipRect();
-
-        ren.drawRoundedRectOutline(inner, shellOutline, innerRadius, 1.5f * s);
-
-        const bool named = m_font && !m_title.empty();
-        if (named) {
-            const nxui::Vec2 measured = m_font->measure(m_title);
-            const float room = std::max(8.f, shell.width - 18.f * s);
-            float textScale = 0.92f * s;
-            if (measured.x > 0.f)
-                textScale = std::min(textScale, room / measured.x);
-            textScale = std::max(0.40f * s, textScale);
-
-            const float textW = measured.x * textScale;
-            const float textH = measured.y * textScale;
-            const nxui::Vec2 textPos{shell.x + (shell.width - textW) * 0.5f,
-                                     shell.y + (shell.height - textH) * 0.52f};
-
-            ren.drawText(m_title, textPos, m_font, titleColor, textScale);
-        } else {
-            const float cell = std::min(shell.width, shell.height) * 0.16f;
-            const float gap = cell * 0.22f;
-            const float gridSize = cell * 2.f + gap;
-            const float gridX = shell.x + (shell.width - gridSize) * 0.5f;
-            const float gridY = shell.y + (shell.height - gridSize) * 0.52f;
-            for (int i = 0; i < 4; ++i) {
-                const int col = i % 2;
-                const int row = i / 2;
-                const nxui::Rect cellRect{gridX + col * (cell + gap),
-                                          gridY + row * (cell + gap), cell, cell};
-                ren.drawRoundedRect(cellRect,
-                                    accent.withAlpha(0.55f * m_opacity),
-                                    cell * 0.22f);
-            }
-        }
-
-        if (m_focused) {
-            ren.drawRoundedRectOutline(shell.expanded(2.f * s),
-                                       accent.withAlpha(0.50f * m_opacity),
-                                       shellRadius + 2.f * s, 2.f * s);
-        }
+        const int style = m_folderStyleIndex;
+        const bool mosaic = style == switchu::folders::kFolderStyleClassic;
+        const float inset = (mosaic ? 10.f : 8.f) * s;
+        switchu::folders::FolderStyleDrawArgs args;
+        args.renderer = &ren;
+        args.bounds = r.shrunk(inset);
+        args.radius = std::max(12.f, rad - 2.f);
+        args.scale = s;
+        args.opacity = m_opacity;
+        args.styleIndex = style;
+        args.accent = switchu::folders::colorForIndex(m_folderColorIndex);
+        args.themeMode = m_themeMode;
+        args.font = m_font;
+        args.title = &m_title;
+        args.cover = m_folderCover;
+        args.showCover = m_folderShowCover;
+        args.focused = m_focused;
+        args.drawName = true;
+        switchu::folders::drawFolderStyle(args);
         return;
     }
 

--- a/projects/menu/src/widgets/GlossyIcon.hpp
+++ b/projects/menu/src/widgets/GlossyIcon.hpp
@@ -46,6 +46,7 @@ public:
     void setFolderPreviewCount(int count) { m_folderPreviewCount = count; }
     void setFolderVisualSeed(std::uint32_t seed) { m_folderVisualSeed = seed; }
     void setFolderColorIndex(int index) { m_folderColorIndex = index; }
+    void setFolderStyleIndex(int index) { m_folderStyleIndex = index; }
     void setFont(nxui::Font* font) { m_font = font; }  // folder tiles carry their name
     void setWidgetData(switchu::widgets::WidgetType type, int columns, int rows,
                        std::string primary, std::string secondary,
@@ -151,6 +152,7 @@ private:
     int           m_folderPreviewCount = 0;
     std::uint32_t m_folderVisualSeed = 0;
     int           m_folderColorIndex = 0;
+    int           m_folderStyleIndex = 1;
     nxui::Font*   m_font = nullptr;
     switchu::widgets::WidgetType m_widgetType = switchu::widgets::WidgetType::Clock;
     int m_widgetColumns = 1;

--- a/projects/menu/src/widgets/GlossyIcon.hpp
+++ b/projects/menu/src/widgets/GlossyIcon.hpp
@@ -2,6 +2,7 @@
 #include <nxui/widgets/GlassWidget.hpp>
 #include <nxui/core/Texture.hpp>
 #include <nxui/core/Animation.hpp>
+#include <nxui/Theme.hpp>
 #include "core/GridModel.hpp"
 #include "sidebar/SidebarAnimation.hpp"
 #include <string>
@@ -47,6 +48,7 @@ public:
     void setFolderVisualSeed(std::uint32_t seed) { m_folderVisualSeed = seed; }
     void setFolderColorIndex(int index) { m_folderColorIndex = index; }
     void setFolderStyleIndex(int index) { m_folderStyleIndex = index; }
+    void setThemeMode(nxui::ThemeMode mode) { m_themeMode = mode; }
     void setFont(nxui::Font* font) { m_font = font; }  // folder tiles carry their name
     void setWidgetData(switchu::widgets::WidgetType type, int columns, int rows,
                        std::string primary, std::string secondary,
@@ -153,6 +155,7 @@ private:
     std::uint32_t m_folderVisualSeed = 0;
     int           m_folderColorIndex = 0;
     int           m_folderStyleIndex = 1;
+    nxui::ThemeMode m_themeMode = nxui::ThemeMode::Dark;
     nxui::Font*   m_font = nullptr;
     switchu::widgets::WidgetType m_widgetType = switchu::widgets::WidgetType::Clock;
     int m_widgetColumns = 1;

--- a/projects/menu/src/widgets/GlossyIcon.hpp
+++ b/projects/menu/src/widgets/GlossyIcon.hpp
@@ -48,6 +48,9 @@ public:
     void setFolderVisualSeed(std::uint32_t seed) { m_folderVisualSeed = seed; }
     void setFolderColorIndex(int index) { m_folderColorIndex = index; }
     void setFolderStyleIndex(int index) { m_folderStyleIndex = index; }
+    void setFolderShowCover(bool show) { m_folderShowCover = show; }
+    void setFolderCoverTexture(nxui::Texture* tex) { m_folderCover = tex; }
+    void setFolderCoverTitleId(std::uint64_t id) { m_folderCoverTitleId = id; }
     void setThemeMode(nxui::ThemeMode mode) { m_themeMode = mode; }
     void setFont(nxui::Font* font) { m_font = font; }  // folder tiles carry their name
     void setWidgetData(switchu::widgets::WidgetType type, int columns, int rows,
@@ -154,7 +157,10 @@ private:
     int           m_folderPreviewCount = 0;
     std::uint32_t m_folderVisualSeed = 0;
     int           m_folderColorIndex = 0;
-    int           m_folderStyleIndex = 1;
+    int           m_folderStyleIndex = 0;
+    bool          m_folderShowCover = false;
+    nxui::Texture* m_folderCover = nullptr;
+    std::uint64_t m_folderCoverTitleId = 0;
     nxui::ThemeMode m_themeMode = nxui::ThemeMode::Dark;
     nxui::Font*   m_font = nullptr;
     switchu::widgets::WidgetType m_widgetType = switchu::widgets::WidgetType::Clock;

--- a/romfs/i18n/en-US.json
+++ b/romfs/i18n/en-US.json
@@ -515,6 +515,10 @@
     "size_small": "Small",
     "size_medium": "Medium",
     "size_large": "Large",
+    "style": "Folder style",
+    "style_desc": "Choose the classic tile look or a translucent glass look.",
+    "style_classic": "Classic",
+    "style_glass": "Glass",
     "items": "items"
   },
   "add": {

--- a/romfs/i18n/en-US.json
+++ b/romfs/i18n/en-US.json
@@ -516,7 +516,7 @@
     "size_medium": "Medium",
     "size_large": "Large",
     "style": "Folder style",
-    "style_desc": "Choose the classic tile look or a translucent glass look.",
+    "style_desc": "Applies Classic or Glass to every folder, including new ones.",
     "style_classic": "Classic",
     "style_glass": "Glass",
     "items": "items"

--- a/romfs/i18n/en-US.json
+++ b/romfs/i18n/en-US.json
@@ -516,9 +516,9 @@
     "size_medium": "Medium",
     "size_large": "Large",
     "style": "Folder style",
-    "style_desc": "Applies Classic or Glass to every folder, including new ones.",
+    "style_desc": "Applies Classic or Simple to every folder, including new ones. Simple follows the active theme.",
     "style_classic": "Classic",
-    "style_glass": "Glass",
+    "style_simple": "Simple",
     "items": "items"
   },
   "add": {

--- a/romfs/i18n/en-US.json
+++ b/romfs/i18n/en-US.json
@@ -516,9 +516,16 @@
     "size_medium": "Medium",
     "size_large": "Large",
     "style": "Folder style",
-    "style_desc": "Applies Classic or Simple to every folder, including new ones. Simple follows the active theme.",
+    "style_desc": "Applies to every folder, including new ones.",
     "style_classic": "Classic",
     "style_simple": "Simple",
+    "style_minimal": "Minimal",
+    "style_tab": "Tab",
+    "style_ring": "Ring",
+    "style_manila": "Manila",
+    "style_label": "Label",
+    "show_cover": "Show cover",
+    "show_cover_desc": "Shows the first game on every folder. Classic keeps the mosaic instead.",
     "items": "items"
   },
   "add": {


### PR DESCRIPTION
## Summary
- Fixes [#95](https://github.com/PoloNX/SwitchU/issues/95): moving/adding games into folders that are not on page 1 no longer pins the edit ghost at the origin and freezes placement.
- Folder style is **global** (stored in `settings.json`) and defaults to **Classic**.
- **Classic** is the original mosaic, now following the active light/dark theme.
- Additional silhouettes: **Simple**, **Minimal**, **Tab**, **Ring**, **Manila**, **Label**.
- **Show cover** overlays the first game in the folder on every style except Classic, which keeps the mosaic.

## Test plan
- [x] From page 2+, Y-move a game onto a folder, enter it, place with A, leave with B
- [x] Open folder options (+): switch styles and confirm **all** folder tiles update
- [x] Toggle Show cover on Simple / Manila / Label / Ring and confirm the first game appears
- [x] Confirm Classic ignores Show cover and stays mosaic
- [x] Create a new folder and confirm it uses the current global style
- [x] Confirm folder color still works
- [x] Reboot and confirm style + cover persist

## Notes
Does not include the unreleased install-refresh daemon change from #98.