### PR TITLE
fix: swap games inside folders instead of inserting a blank tile

### DIFF
--- a/projects/menu/src/core/FolderStore.cpp
+++ b/projects/menu/src/core/FolderStore.cpp
@@ -299,12 +299,31 @@ bool FolderStore::placeTitle(std::uint32_t folderId, std::uint64_t titleId,
         return false;
 
     const std::uint32_t previous = folderForTitle(titleId);
+
+    // Reordering inside the same folder must swap (or relocate into a hole),
+    // matching the HOME menu. Zeroing the source and inserting at the target
+    // left a blank tile and shifted everything after it.
+    if (previous == folderId) {
+        auto it = std::find(target->titleIds.begin(), target->titleIds.end(), titleId);
+        if (it == target->titleIds.end())
+            return false;
+        const std::size_t sourceIndex =
+            static_cast<std::size_t>(it - target->titleIds.begin());
+        if (index == sourceIndex)
+            return true;
+        if (index >= target->titleIds.size())
+            target->titleIds.resize(index + 1, 0);
+        std::swap(target->titleIds[sourceIndex], target->titleIds[index]);
+        trimTrailingHoles(target->titleIds);
+        return true;
+    }
+
     if (previous != 0) {
         Folder* source = find(previous);
         if (source) {
             auto it = std::find(source->titleIds.begin(), source->titleIds.end(), titleId);
             if (it != source->titleIds.end()) {
-                *it = 0;  
+                *it = 0;
                 trimTrailingHoles(source->titleIds);
             }
         }

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -625,6 +625,8 @@ bool WiiUMenuApp::activateEditModeTarget() {
     }
 
     if (m_openFolderId != 0 && m_editHeldTitleId < kFolderTitleIdPrefix) {
+        // Folder order lives in folders.json, not the HOME layoutSlots swap.
+        // Same-folder drops swap in place; inbound drops still insert.
         const std::uint32_t targetFolderId = m_openFolderId;
         if (!m_folderStore.placeTitle(targetFolderId, m_editHeldTitleId,
                                       static_cast<std::size_t>(target)) ||


### PR DESCRIPTION
## Summary
- Inside a folder, dropping a game onto another game now **swaps** them, matching the HOME menu.
- Previously the source slot was cleared and the game was **inserted** at the target, which left a blank tile and shifted every title after it.

## Test plan
- [x] HOME: Y-move a game onto another game — they swap, no extra blanks
- [x] Inside a folder: Y-move a game onto another game — they swap, no extra blanks, nothing shifts
- [x] Inside a folder: Y-move a game onto an empty slot — it relocates, old slot is empty
- [x] From HOME, drop a game into an open folder (occupied or empty) — still places into the folder

## Notes
Separate from #100 (folder styles). This only changes in-folder reorder.