### PR TITLE
feat: instant HOME return via leave-frame splash

### DIFF
--- a/lib/nxui/include/nxui/Activity.hpp
+++ b/lib/nxui/include/nxui/Activity.hpp
@@ -26,6 +26,11 @@ class Activity {
 public:
     virtual ~Activity() = default;
 
+    /// Optional first paint before onCreate(). Return true if this drew
+    /// something meaningful (e.g. a leave-frame splash) so Application can
+    /// skip the default black clear frame.
+    virtual bool presentInitialFrame(Renderer& /*ren*/) { return false; }
+
     /// Called once after GPU / Renderer / Input are ready.
     virtual bool onCreate() { return true; }
 
@@ -39,6 +44,10 @@ public:
     /// The rootBox is rendered before this, so anything drawn here
     /// appears on top of the widget tree (useful for overlays).
     virtual void onRender(Renderer& ren) {}
+
+    /// Called after a frame has been submitted/presented. Safe place for
+    /// GPU→CPU framebuffer readback without interrupting the render pass.
+    virtual void onAfterPresent(Renderer& /*ren*/) {}
 
     /// Access the parent Application (set by Application::setActivity).
     Application& app() { return *m_app; }

--- a/lib/nxui/include/nxui/core/GpuDevice.hpp
+++ b/lib/nxui/include/nxui/core/GpuDevice.hpp
@@ -74,6 +74,14 @@ public:
     void endFrame();
     void waitIdle();
 
+    /// Copy the most recently presented framebuffer into tightly-packed RGBA8.
+    /// When halfRes is true, downsamples to FB_WIDTH/2 x FB_HEIGHT/2 via the
+    /// existing offscreen target. Must be called outside beginFrame/endFrame
+    /// (e.g. from Activity::onAfterPresent).
+    bool downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                 int& outW, int& outH,
+                                 bool halfRes = true);
+
     int  width()  const { return FB_WIDTH; }
     int  height() const { return FB_HEIGHT; }
 

--- a/lib/nxui/include/nxui/core/Renderer.hpp
+++ b/lib/nxui/include/nxui/core/Renderer.hpp
@@ -111,6 +111,11 @@ public:
                                float radius, const Color& tint = Color::white());
     void drawText(const std::string& text, const Vec2& pos, Font* font, const Color& color, float scale = 1.f);
 
+    /// GPU→CPU readback of the last presented framebuffer. See GpuDevice.
+    bool downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                 int& outW, int& outH,
+                                 bool halfRes = true);
+
     // Post-processing
     void captureToOffscreen(bool reuseIfValid = false);
     void copyOffscreen(int srcTarget, int dstTarget);

--- a/lib/nxui/src/core/Application.cpp
+++ b/lib/nxui/src/core/Application.cpp
@@ -52,8 +52,11 @@ bool Application::initialize() {
 
     // Present one clean frame immediately so that stale framebuffer
     // content from a previous process is never visible on screen.
+    // Activities may replace the default black with a leave-frame splash.
     m_gpu.beginFrame();
     m_renderer->beginFrame();
+    if (m_activity)
+        m_activity->presentInitialFrame(*m_renderer);
     m_renderer->endFrame();
     m_gpu.endFrame();
 
@@ -220,6 +223,7 @@ void Application::run() {
                 m_activity->onRender(*m_renderer);
                 m_renderer->endFrame();
                 m_gpu.endFrame();
+                m_activity->onAfterPresent(*m_renderer);
             } else {
                 // Yield CPU while another app owns the foreground.
                 svcSleepThread(100000000LL); // 100 ms

--- a/lib/nxui/src/core/GpuDevice.cpp
+++ b/lib/nxui/src/core/GpuDevice.cpp
@@ -168,6 +168,99 @@ void GpuDevice::endFrame() {
     m_queue.presentImage(m_swapchain, m_slot);
 }
 
+bool GpuDevice::downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                        int& outW, int& outH,
+                                        bool halfRes) {
+    if (m_slot < 0 || !m_queue)
+        return false;
+
+    waitForTextureUploads();
+    waitIdle();
+
+    const int fullW = FB_WIDTH;
+    const int fullH = FB_HEIGHT;
+    const bool useHalf = halfRes && m_offscreenReady;
+    outW = useHalf ? fullW / 2 : fullW;
+    outH = useHalf ? fullH / 2 : fullH;
+    if (outW <= 0 || outH <= 0)
+        return false;
+
+    const uint32_t byteSize = static_cast<uint32_t>(outW) * static_cast<uint32_t>(outH) * 4u;
+    const uint32_t stagingSize = (byteSize + kGpuAlign - 1) & ~(kGpuAlign - 1);
+    auto staging = dk::MemBlockMaker{m_dev, stagingSize}
+        .setFlags(DkMemBlockFlags_CpuUncached | DkMemBlockFlags_GpuCached)
+        .create();
+    if (!staging || !staging.getCpuAddr())
+        return false;
+
+    // Full-res path needs an uncompressed blit target: swapchain images use
+    // HwCompression, and copyImageToBuffer from those is unreliable / soft.
+    dk::Image tempImage;
+    dk::UniqueMemBlock tempImageMem;
+    if (!useHalf) {
+        dk::ImageLayout layout;
+        dk::ImageLayoutMaker{m_dev}
+            .setFlags(DkImageFlags_UsageRender | DkImageFlags_Usage2DEngine)
+            .setFormat(DkImageFormat_RGBA8_Unorm)
+            .setDimensions(static_cast<uint32_t>(fullW), static_cast<uint32_t>(fullH))
+            .initialize(layout);
+        const uint32_t imgSize =
+            (static_cast<uint32_t>(layout.getSize()) + kGpuAlign - 1) & ~(kGpuAlign - 1);
+        tempImageMem = dk::MemBlockMaker{m_dev, imgSize}
+            .setFlags(DkMemBlockFlags_GpuCached | DkMemBlockFlags_Image)
+            .create();
+        if (!tempImageMem)
+            return false;
+        tempImage.initialize(layout, tempImageMem, 0);
+    }
+
+    m_uploadCmdbuf.clear();
+    m_uploadCmdbuf.addMemory(m_uploadCmdPool.block, 0, 64 * 1024);
+
+    dk::ImageView srcView{m_fbImages[m_slot]};
+    m_uploadCmdbuf.barrier(DkBarrier_Full, DkInvalidateFlags_Image);
+    if (useHalf) {
+        dk::ImageView dstView{m_offImages[0]};
+        const DkImageRect srcRect{0, 0, 0,
+                                  static_cast<uint32_t>(fullW),
+                                  static_cast<uint32_t>(fullH), 1};
+        const DkImageRect dstRect{0, 0, 0,
+                                  static_cast<uint32_t>(outW),
+                                  static_cast<uint32_t>(outH), 1};
+        m_uploadCmdbuf.blitImage(srcView, srcRect, dstView, dstRect, 0);
+        m_uploadCmdbuf.barrier(DkBarrier_Full, DkInvalidateFlags_Image);
+        srcView = dk::ImageView{m_offImages[0]};
+    } else {
+        dk::ImageView dstView{tempImage};
+        const DkImageRect rect{0, 0, 0,
+                               static_cast<uint32_t>(fullW),
+                               static_cast<uint32_t>(fullH), 1};
+        m_uploadCmdbuf.blitImage(srcView, rect, dstView, rect, 0);
+        m_uploadCmdbuf.barrier(DkBarrier_Full, DkInvalidateFlags_Image);
+        srcView = dstView;
+    }
+
+    const DkImageRect copyRect{0, 0, 0,
+                               static_cast<uint32_t>(outW),
+                               static_cast<uint32_t>(outH), 1};
+    m_uploadCmdbuf.copyImageToBuffer(
+        srcView, copyRect,
+        DkCopyBuf{staging.getGpuAddr(), 0, 0});
+
+    // Force a 3D-engine sync so the copy finishes before CPU reads.
+    // See deko3d notes on copyImageToBuffer + L2 invalidation.
+    const uint32_t threedNop = 0x80000040u;
+    m_uploadCmdbuf.replayCmds({threedNop});
+    m_uploadCmdbuf.barrier(DkBarrier_None, DkInvalidateFlags_L2Cache);
+
+    m_queue.submitCommands(m_uploadCmdbuf.finishList());
+    m_queue.waitIdle();
+
+    outRgba.resize(byteSize);
+    std::memcpy(outRgba.data(), staging.getCpuAddr(), byteSize);
+    return true;
+}
+
 void GpuDevice::waitIdle() {
     if (m_queue) m_queue.waitIdle();
 }

--- a/lib/nxui/src/core/GpuDevice_sdl2.cpp
+++ b/lib/nxui/src/core/GpuDevice_sdl2.cpp
@@ -48,4 +48,14 @@ void GpuDevice::waitIdle() {
     // No-op for SDL2 — rendering is synchronous
 }
 
+bool GpuDevice::downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                        int& outW, int& outH,
+                                        bool halfRes) {
+    (void)outRgba;
+    (void)outW;
+    (void)outH;
+    (void)halfRes;
+    return false;
+}
+
 } // namespace nxui

--- a/lib/nxui/src/core/Renderer.cpp
+++ b/lib/nxui/src/core/Renderer.cpp
@@ -452,6 +452,13 @@ void Renderer::captureToOffscreen(bool reuseIfValid) {
     m_reusableOffscreenCaptureValid = reuseIfValid;
 }
 
+bool Renderer::downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                       int& outW, int& outH,
+                                       bool halfRes) {
+    flush();
+    return m_gpu.downloadFramebufferRgba(outRgba, outW, outH, halfRes);
+}
+
 void Renderer::copyOffscreen(int srcTarget, int dstTarget) {
     if (!m_gpu.offscreenReady()) return;
     if (srcTarget < 0 || srcTarget >= GpuDevice::NUM_OFFSCREEN) return;

--- a/lib/nxui/src/core/Renderer_sdl2.cpp
+++ b/lib/nxui/src/core/Renderer_sdl2.cpp
@@ -466,6 +466,16 @@ void Renderer::captureToOffscreen(bool reuseIfValid) {
     // No-op: SDL2 backend has no offscreen render targets.
 }
 
+bool Renderer::downloadFramebufferRgba(std::vector<uint8_t>& outRgba,
+                                       int& outW, int& outH,
+                                       bool halfRes) {
+    (void)outRgba;
+    (void)outW;
+    (void)outH;
+    (void)halfRes;
+    return false;
+}
+
 void Renderer::copyOffscreen(int srcTarget, int dstTarget) {
     (void)srcTarget;
     (void)dstTarget;

--- a/projects/menu/src/core/LeaveFrameCache.cpp
+++ b/projects/menu/src/core/LeaveFrameCache.cpp
@@ -1,0 +1,137 @@
+#include "LeaveFrameCache.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+namespace LeaveFrameCache {
+namespace {
+
+constexpr std::uint32_t kMagic = 0x4C555753u; // 'SWUL' LE
+constexpr std::uint32_t kVersion = 1;
+constexpr int kMaxSide = 1280;
+constexpr std::size_t kMaxPixels = static_cast<std::size_t>(kMaxSide) * static_cast<std::size_t>(kMaxSide);
+
+#pragma pack(push, 1)
+struct Header {
+    std::uint32_t magic = 0;
+    std::uint32_t version = 0;
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::uint32_t page = 0;
+    std::uint32_t openFolderId = 0;
+    std::uint64_t focusTitleId = 0;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(Header) == 32, "LeaveFrameCache header size");
+
+bool readHeader(std::ifstream& in, Header& header) {
+    in.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (!in || in.gcount() != static_cast<std::streamsize>(sizeof(header)))
+        return false;
+    if (header.magic != kMagic || header.version != kVersion)
+        return false;
+    if (header.width == 0 || header.height == 0)
+        return false;
+    if (header.width > static_cast<std::uint32_t>(kMaxSide)
+        || header.height > static_cast<std::uint32_t>(kMaxSide))
+        return false;
+    const std::size_t pixels = static_cast<std::size_t>(header.width)
+                             * static_cast<std::size_t>(header.height);
+    if (pixels > kMaxPixels)
+        return false;
+    return true;
+}
+
+} // namespace
+
+bool save(const LeaveFrameSession& session,
+          const std::uint8_t* rgba, int width, int height) {
+    if (!rgba || width <= 0 || height <= 0 || width > kMaxSide || height > kMaxSide)
+        return false;
+
+    std::error_code ec;
+    std::filesystem::create_directories("sdmc:/config/SwitchU", ec);
+
+    Header header{};
+    header.magic = kMagic;
+    header.version = kVersion;
+    header.width = static_cast<std::uint32_t>(width);
+    header.height = static_cast<std::uint32_t>(height);
+    header.page = session.page < 0 ? 0u : static_cast<std::uint32_t>(session.page);
+    header.openFolderId = session.openFolderId;
+    header.focusTitleId = session.focusTitleId;
+
+    const std::size_t bytes = static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4u;
+    const std::string tmpPath = std::string(kPath) + ".tmp";
+
+    {
+        std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
+        if (!out)
+            return false;
+        out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+        out.write(reinterpret_cast<const char*>(rgba), static_cast<std::streamsize>(bytes));
+        if (!out)
+            return false;
+    }
+
+    std::filesystem::remove(kPath, ec);
+    std::filesystem::rename(tmpPath, kPath, ec);
+    if (ec) {
+        std::filesystem::remove(tmpPath, ec);
+        return false;
+    }
+    return true;
+}
+
+bool load(LeaveFrameSession& session, LeaveFrameImage& image) {
+    session = {};
+    image = {};
+
+    std::ifstream in(kPath, std::ios::binary);
+    if (!in)
+        return false;
+
+    Header header{};
+    if (!readHeader(in, header))
+        return false;
+
+    const std::size_t bytes = static_cast<std::size_t>(header.width)
+                            * static_cast<std::size_t>(header.height) * 4u;
+    image.rgba.resize(bytes);
+    in.read(reinterpret_cast<char*>(image.rgba.data()), static_cast<std::streamsize>(bytes));
+    if (!in || in.gcount() != static_cast<std::streamsize>(bytes)) {
+        image = {};
+        return false;
+    }
+
+    image.width = static_cast<int>(header.width);
+    image.height = static_cast<int>(header.height);
+    session.valid = true;
+    session.page = static_cast<int>(header.page);
+    session.openFolderId = header.openFolderId;
+    session.focusTitleId = header.focusTitleId;
+    return image.valid();
+}
+
+bool loadSessionOnly(LeaveFrameSession& session) {
+    session = {};
+    std::ifstream in(kPath, std::ios::binary);
+    if (!in)
+        return false;
+
+    Header header{};
+    if (!readHeader(in, header))
+        return false;
+
+    session.valid = true;
+    session.page = static_cast<int>(header.page);
+    session.openFolderId = header.openFolderId;
+    session.focusTitleId = header.focusTitleId;
+    return true;
+}
+
+} // namespace LeaveFrameCache

--- a/projects/menu/src/core/LeaveFrameCache.hpp
+++ b/projects/menu/src/core/LeaveFrameCache.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// Persists a half-resolution snapshot of HOME for fast AppletReturn paint,
+/// plus lightweight session state (page / folder / focus) so the live UI can
+/// land on the same view as the splash.
+struct LeaveFrameSession {
+    bool valid = false;
+    int page = 0;
+    std::uint32_t openFolderId = 0;
+    std::uint64_t focusTitleId = 0;
+};
+
+struct LeaveFrameImage {
+    int width = 0;
+    int height = 0;
+    std::vector<std::uint8_t> rgba;
+    bool valid() const {
+        return width > 0 && height > 0
+            && rgba.size() == static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4u;
+    }
+};
+
+namespace LeaveFrameCache {
+
+inline constexpr const char* kPath = "sdmc:/config/SwitchU/leave_frame.bin";
+
+bool save(const LeaveFrameSession& session,
+          const std::uint8_t* rgba, int width, int height);
+
+bool load(LeaveFrameSession& session, LeaveFrameImage& image);
+
+bool loadSessionOnly(LeaveFrameSession& session);
+
+} // namespace LeaveFrameCache

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -7,6 +7,7 @@
 #include <nxui/core/I18n.hpp>
 #include "DebugLog.hpp"
 #include "bluetooth/BluetoothManager.hpp"
+#include "LeaveFrameCache.hpp"
 #include <switch.h>
 #ifdef SWITCHU_MENU
 #include "smi_commands.hpp"
@@ -304,6 +305,202 @@ void WiiUMenuApp::setStartupStatus(const switchu::smi::SystemStatus& status, boo
     m_fastReturnRequested = fastReturn || status.suspended_app_id != 0;
 }
 #endif
+
+bool WiiUMenuApp::presentInitialFrame(nxui::Renderer& ren) {
+#ifdef SWITCHU_MENU
+    if (!m_fastReturnRequested)
+        return false;
+
+    LeaveFrameImage image;
+    if (LeaveFrameCache::load(m_leaveSession, image) && image.valid()
+        && m_leaveSplashTex.loadFromPixels(app().gpu(), ren,
+                                           image.rgba.data(), image.width, image.height)) {
+        ren.drawTexture(&m_leaveSplashTex, {0.f, 0.f, 1280.f, 720.f});
+        m_leaveSplashDrawn = true;
+        m_leaveSplashPhase = LeaveSplashPhase::Hold;
+        m_leaveSplashHoldRemaining = kLeaveSplashHoldDur;
+        m_leaveSplashFade = 1.f;
+        m_leaveMotionFreezePending = true;
+        DebugLog::log("[leave] splash %dx%d page=%d folder=%u focus=%016lX",
+                      image.width, image.height, m_leaveSession.page,
+                      m_leaveSession.openFolderId,
+                      static_cast<unsigned long>(m_leaveSession.focusTitleId));
+        return true;
+    }
+
+    // No cached frame — still avoid pure black while onCreate runs.
+    ren.drawRect({0.f, 0.f, 1280.f, 720.f}, nxui::Color(0.07f, 0.12f, 0.18f, 1.f));
+    m_leaveSplashDrawn = true;
+    m_leaveSplashPhase = LeaveSplashPhase::None;
+    m_leaveSplashFade = 0.f;
+    DebugLog::log("[leave] splash fallback solid");
+    return true;
+#else
+    (void)ren;
+    return false;
+#endif
+}
+
+void WiiUMenuApp::scheduleLeaveCapture(std::function<void()> afterCapture) {
+    if (m_leaveCapturePending) {
+        if (!afterCapture)
+            return;
+        if (m_leaveCaptureAfter) {
+            auto prev = std::move(m_leaveCaptureAfter);
+            m_leaveCaptureAfter = [prev = std::move(prev),
+                                   next = std::move(afterCapture)]() mutable {
+                if (prev) prev();
+                if (next) next();
+            };
+        } else {
+            m_leaveCaptureAfter = std::move(afterCapture);
+        }
+        return;
+    }
+    m_leaveCapturePending = true;
+    m_leaveCaptureAfter = std::move(afterCapture);
+}
+
+LeaveFrameSession WiiUMenuApp::captureLeaveSession() const {
+    LeaveFrameSession session;
+    session.valid = true;
+    session.openFolderId = m_openFolderId;
+    session.page = m_grid ? m_grid->currentPage() : 0;
+    session.focusTitleId = 0;
+
+    if (auto* cur = focusManager().current()) {
+        if (cur->tag() == "glossy_icon")
+            session.focusTitleId = static_cast<const GlossyIcon*>(cur)->titleId();
+    }
+    if (session.focusTitleId == 0 && m_grid) {
+        const int idx = m_grid->focusedGlobalIndex();
+        const auto& icons = m_grid->allIcons();
+        if (idx >= 0 && idx < static_cast<int>(icons.size()) && icons[idx])
+            session.focusTitleId = icons[idx]->titleId();
+    }
+    return session;
+}
+
+bool WiiUMenuApp::saveLeaveFrame(nxui::Renderer& ren) {
+    std::vector<std::uint8_t> rgba;
+    int width = 0;
+    int height = 0;
+    if (!ren.downloadFramebufferRgba(rgba, width, height, false)) {
+        DebugLog::log("[leave] framebuffer download failed");
+        return false;
+    }
+
+    const LeaveFrameSession session = captureLeaveSession();
+    if (!LeaveFrameCache::save(session, rgba.data(), width, height)) {
+        DebugLog::log("[leave] cache write failed");
+        return false;
+    }
+
+    DebugLog::log("[leave] saved %dx%d page=%d folder=%u focus=%016lX",
+                  width, height, session.page, session.openFolderId,
+                  static_cast<unsigned long>(session.focusTitleId));
+    return true;
+}
+
+void WiiUMenuApp::onAfterPresent(nxui::Renderer& ren) {
+    if (!m_leaveCapturePending)
+        return;
+
+    m_leaveCapturePending = false;
+    saveLeaveFrame(ren);
+    if (m_leaveCaptureAfter) {
+        auto after = std::move(m_leaveCaptureAfter);
+        m_leaveCaptureAfter = {};
+        after();
+    }
+}
+
+void WiiUMenuApp::restoreLeaveSession() {
+    if (!m_leaveSession.valid || !m_grid)
+        return;
+
+    const LeaveFrameSession session = m_leaveSession;
+    m_leaveSession.valid = false;
+
+    if (session.openFolderId != 0 && m_folderStore.find(session.openFolderId)) {
+        m_requestedFolderId = session.openFolderId;
+        m_folderOpenFocusTitleId = session.focusTitleId;
+        openCapturedFolder();
+        DebugLog::log("[leave] restored folder=%u focus=%016lX",
+                      session.openFolderId,
+                      static_cast<unsigned long>(session.focusTitleId));
+        return;
+    }
+
+    if (session.page > 0)
+        m_grid->setPage(session.page);
+
+    if (session.focusTitleId != 0) {
+        const int idx = findTitleIndex(session.focusTitleId);
+        if (idx >= 0 && m_grid->focusGlobalIndex(idx)) {
+            if (auto* focused = m_grid->focusManager().current())
+                focusManager().setFocus(focused);
+        }
+    }
+
+    DebugLog::log("[leave] restored page=%d focus=%016lX",
+                  session.page, static_cast<unsigned long>(session.focusTitleId));
+}
+
+bool WiiUMenuApp::leaveSplashActive() const {
+    return m_leaveSplashPhase != LeaveSplashPhase::None;
+}
+
+void WiiUMenuApp::setLeaveMotionFrozen(bool frozen) {
+    if (m_leaveMotionFrozen == frozen)
+        return;
+    m_leaveMotionFrozen = frozen;
+
+    if (m_background)
+        m_background->setMotionPaused(frozen);
+    if (m_cursor)
+        m_cursor->setMotionPaused(frozen);
+    if (m_pointerCursor)
+        m_pointerCursor->setMotionPaused(frozen);
+    if (m_grid) {
+        for (auto& icon : m_grid->allIcons()) {
+            if (icon)
+                icon->setMotionPaused(frozen);
+        }
+    }
+}
+
+void WiiUMenuApp::updateLeaveSplashHandoff(float dt) {
+    if (m_leaveMotionFreezePending && m_background) {
+        setLeaveMotionFrozen(true);
+        m_leaveMotionFreezePending = false;
+        // Snap the cursor so the live frame under the splash matches focus.
+        if (m_cursor && focusManager().current()) {
+            m_cursor->moveTo(focusManager().current()->focusRect().expanded(4.f), 0.f);
+            m_cursor->setVisible(true);
+        }
+    }
+
+    if (m_leaveSplashPhase == LeaveSplashPhase::Hold) {
+        m_leaveSplashHoldRemaining -= dt;
+        if (m_leaveSplashHoldRemaining <= 0.f) {
+            m_leaveSplashHoldRemaining = 0.f;
+            m_leaveSplashPhase = LeaveSplashPhase::Fade;
+            DebugLog::log("[leave] splash crossfade begin");
+        }
+        return;
+    }
+
+    if (m_leaveSplashPhase == LeaveSplashPhase::Fade) {
+        m_leaveSplashFade = std::max(0.f, m_leaveSplashFade - dt / kLeaveSplashFadeDur);
+        if (m_leaveSplashFade <= 0.f) {
+            m_leaveSplashFade = 0.f;
+            m_leaveSplashPhase = LeaveSplashPhase::None;
+            setLeaveMotionFrozen(false);
+            DebugLog::log("[leave] splash handoff complete");
+        }
+    }
+}
 
 bool WiiUMenuApp::onCreate() {
     const std::uint64_t initStartTick = armGetSystemTick();
@@ -630,7 +827,7 @@ void WiiUMenuApp::appendAddUserButton() {
     add->setOnActivate([this]() {
         m_audio.playSfx(Sfx::Activate);
 #ifdef SWITCHU_MENU
-        m_launcher.launchUserCreator();
+        scheduleLeaveCapture([this]() { m_launcher.launchUserCreator(); });
 #endif
     });
     m_userAvatarButtons.push_back(add);
@@ -727,7 +924,7 @@ void WiiUMenuApp::loadNextUserAvatar() {
     avatar->setOnActivate([this, uid]() {
         m_audio.playSfx(Sfx::Activate);
 #ifdef SWITCHU_MENU
-        m_launcher.launchUserPage(uid);
+        scheduleLeaveCapture([this, uid]() { m_launcher.launchUserPage(uid); });
 #endif
     });
 
@@ -2782,16 +2979,18 @@ void WiiUMenuApp::activateApplication(GlossyIcon* source, AppEntry* entry,
                                       const std::string& launchTitle) {
     if (!source || titleId == 0) return;
     if (m_launcher.isAppSuspended(titleId)) {
-        m_audio.playSfx(Sfx::LaunchGame);
-        m_launchAnim->start(source->focusRect(), source->texture(),
-            source->cornerRadius(), m_theme.panelBase, m_theme.panelBorder,
-            0, {}, nullptr,
-            [this, titleId, launchTitle]() {
-                m_widgetStore.recordLaunch(titleId, launchTitle,
-                    static_cast<std::int64_t>(std::time(nullptr)));
-                m_widgetStore.save();
-                m_launcher.resumeApplication();
-            });
+        scheduleLeaveCapture([this, source, titleId, launchTitle]() {
+            m_audio.playSfx(Sfx::LaunchGame);
+            m_launchAnim->start(source->focusRect(), source->texture(),
+                source->cornerRadius(), m_theme.panelBase, m_theme.panelBorder,
+                0, {}, nullptr,
+                [this, titleId, launchTitle]() {
+                    m_widgetStore.recordLaunch(titleId, launchTitle,
+                        static_cast<std::int64_t>(std::time(nullptr)));
+                    m_widgetStore.save();
+                    m_launcher.resumeApplication();
+                });
+        });
         return;
     }
 
@@ -2823,14 +3022,17 @@ void WiiUMenuApp::activateApplication(GlossyIcon* source, AppEntry* entry,
     const nxui::Color border = m_theme.panelBorder;
     auto startLaunch = [this, frame, texture, radius, base, border,
                         titleId, launchTitle](AccountUid uid) {
-        m_audio.playSfx(Sfx::LaunchGame);
-        m_launchAnim->start(frame, texture, radius, base, border, titleId, uid,
-            [this, launchTitle](std::uint64_t id, AccountUid selectedUid) {
-                m_widgetStore.recordLaunch(id, launchTitle,
-                    static_cast<std::int64_t>(std::time(nullptr)));
-                m_widgetStore.save();
-                m_launcher.launchApplication(id, selectedUid);
-            });
+        scheduleLeaveCapture([this, frame, texture, radius, base, border,
+                              titleId, launchTitle, uid]() {
+            m_audio.playSfx(Sfx::LaunchGame);
+            m_launchAnim->start(frame, texture, radius, base, border, titleId, uid,
+                [this, launchTitle](std::uint64_t id, AccountUid selectedUid) {
+                    m_widgetStore.recordLaunch(id, launchTitle,
+                        static_cast<std::int64_t>(std::time(nullptr)));
+                    m_widgetStore.save();
+                    m_launcher.launchApplication(id, selectedUid);
+                });
+        });
     };
 
     if (entry) {
@@ -3051,131 +3253,11 @@ std::shared_ptr<GlossyIcon> WiiUMenuApp::makeIcon(const AppEntry& entry) {
 
     GlossyIcon* raw = icon.get();
     icon->setOnActivate([this, raw]() {
-        uint64_t tid = raw->titleId();
-        if (m_launcher.isAppSuspended(tid)) {
-            m_audio.playSfx(Sfx::LaunchGame);
-            nxui::Rect   fr   = raw->focusRect();
-            const nxui::Texture* tex = raw->texture();
-            float  cr   = raw->cornerRadius();
-            nxui::Color  base = m_theme.panelBase;
-            nxui::Color  bord = m_theme.panelBorder;
-            m_launchAnim->start(fr, tex, cr, base, bord, 0, {},
-                nullptr,
-                [this, tid, title = raw->title()]() {
-                    m_widgetStore.recordLaunch(tid, title,
-                        static_cast<std::int64_t>(std::time(nullptr)));
-                    m_widgetStore.save();
-                    m_launcher.resumeApplication();
-                });
-        } else {
-            AppEntry* entry = nullptr;
-            int entryIndex = findTitleIndex(tid);
-            if (entryIndex >= 0)
-                entry = &m_model.at(entryIndex);
-            if (entry && !entry->isLaunchable()) {
-                m_audio.playSfx(Sfx::ModalShow);
-                m_dialogReturnFocus = raw;
-                std::string reason;
-                auto& i18n = nxui::I18n::instance();
-                if (entry->isGameCardNotInserted())
-                    reason = i18n.tr("error.gamecard_not_inserted", "Game card is not inserted.");
-                else if (entry->needsVerify())
-                    reason = i18n.tr("error.needs_verify", "Game data needs verification.");
-                else if (entry->needsUpdate())
-                    reason = i18n.tr("error.needs_update", "A required update is available.");
-                else if (!entry->hasContents())
-                    reason = i18n.tr("error.no_contents", "Game data is missing.");
-                else
-                    reason = i18n.tr("error.cannot_launch", "This game cannot be launched.");
-                m_dialog->show(
-                    i18n.tr("error.title", "Cannot Launch"),
-                    reason,
-                    {{i18n.tr("button.ok", "OK"), [this]() {}, true}},
-                    0, {}
-                );
-                focusManager().setFocus(m_dialog.get());
-                return;
-            }
-
-            nxui::Rect   fr   = raw->focusRect();
-            const nxui::Texture* tex = raw->texture();
-            float  cr   = raw->cornerRadius();
-            nxui::Color  base = m_theme.panelBase;
-            nxui::Color  bord = m_theme.panelBorder;
-            const std::string launchTitle = raw->title();
-            auto startLaunch = [this, fr, tex, cr, base, bord, tid, launchTitle](AccountUid uid) {
-                m_audio.playSfx(Sfx::LaunchGame);
-                m_launchAnim->start(fr, tex, cr, base, bord, tid, uid,
-                    [this, launchTitle](uint64_t id, AccountUid u) {
-                        m_widgetStore.recordLaunch(id, launchTitle,
-                            static_cast<std::int64_t>(std::time(nullptr)));
-                        m_widgetStore.save();
-                        m_launcher.launchApplication(id, u);
-                    });
-            };
-            if (entry) {
-                if (!entry->startupUserKnown) {
-                    entry->startupUserAccount = 1;
-                    entry->startupUserAccountOption = 0;
-                    entry->userRequired = true;
-                }
-                DebugLog::log("[launcher] user decision tid=%016lX startup_user=%u option=%u interactive_user=%d",
-                              tid,
-                              (unsigned)entry->startupUserAccount,
-                              (unsigned)entry->startupUserAccountOption,
-                              entry->userRequired ? 1 : 0);
-
-                if (entry->startupUserAccount == 0) {
-                    AccountUid emptyUid = {};
-                    DebugLog::log("[launcher] skipping user select: NACP StartupUserAccount=None");
-                    startLaunch(emptyUid);
-                    return;
-                }
-
-                if (m_config.defaultProfileEnabled) {
-                    AccountUid defaultUid = {};
-                    if (hexToAccountUid(m_config.defaultProfileUid, defaultUid)) {
-                        DebugLog::log("[launcher] skipping user select: default profile configured uid[0]=0x%016lX uid[1]=0x%016lX",
-                                      defaultUid.uid[0], defaultUid.uid[1]);
-                        startLaunch(defaultUid);
-                        return;
-                    }
-                    DebugLog::log("[launcher] default profile enabled but uid is invalid");
-                }
-
-                AccountUid silentUid = {};
-                const bool networkRequired = entry->startupUserAccount == 2;
-                Result silentRc = accountTrySelectUserWithoutInteraction(&silentUid, networkRequired);
-                DebugLog::log("[launcher] TrySelectUserWithoutInteraction network_required=%d rc=0x%X uid_valid=%d uid[0]=0x%016lX uid[1]=0x%016lX",
-                              networkRequired ? 1 : 0,
-                              silentRc,
-                              accountUidIsValid(&silentUid) ? 1 : 0,
-                              silentUid.uid[0],
-                              silentUid.uid[1]);
-                if (R_SUCCEEDED(silentRc) && accountUidIsValid(&silentUid)) {
-                    DebugLog::log("[launcher] skipping user select: silent account selection succeeded");
-                    startLaunch(silentUid);
-                    return;
-                }
-
-                if (!entry->userRequired) {
-                    AccountUid emptyUid = {};
-                    DebugLog::log("[launcher] skipping user select fallback: startup_user=%u option=%u did not require interactive picker",
-                                  (unsigned)entry->startupUserAccount,
-                                  (unsigned)entry->startupUserAccountOption);
-                    startLaunch(emptyUid);
-                    return;
-                }
-            }
-            if (m_userSelect) {
-                bool usersLoaded = m_userSelect->loadUsers(app().gpu(), app().renderer());
-                DebugLog::log("[UserSelect] lazy load result=%d", usersLoaded ? 1 : 0);
-                if (usersLoaded)
-                    m_audio.playSfx(Sfx::ModalShow);
-            }
-            m_userSelect->showUserSelect([startLaunch](AccountUid uid) { startLaunch(uid); });
-            focusManager().setFocus(m_userSelect.get());
-        }
+        AppEntry* appEntry = nullptr;
+        const int entryIndex = findTitleIndex(raw->titleId());
+        if (entryIndex >= 0)
+            appEntry = &m_model.at(entryIndex);
+        activateApplication(raw, appEntry, raw->titleId(), raw->title());
     });
 #else
     icon->setOnActivate([this]() {
@@ -3362,9 +3444,13 @@ void WiiUMenuApp::buildGrid() {
         updateCursor();
     });
 
-    int initialPage = 0;
+    // Prefer the leave-frame session (page/folder/focus) when returning from a
+    // title or applet so the live UI matches the splash we just showed.
 #ifdef SWITCHU_MENU
-    if (m_launcher.suspendedTitleId() != 0) {
+    if (m_leaveSession.valid) {
+        restoreLeaveSession();
+    } else if (m_launcher.suspendedTitleId() != 0) {
+        int initialPage = 0;
         int suspendedIndex = findTitleIndex(m_launcher.suspendedTitleId());
         if (suspendedIndex >= 0 && m_grid->iconsPerPage() > 0)
             initialPage = suspendedIndex / m_grid->iconsPerPage();
@@ -3409,9 +3495,15 @@ void WiiUMenuApp::buildGrid() {
 
     SidebarManager::Actions sidebarActions;
 #ifdef SWITCHU_MENU
-    sidebarActions.onAlbum       = [this]() { m_launcher.launchAlbum(); };
-    sidebarActions.onMiiEditor   = [this]() { m_launcher.launchMiiEditor(); };
-    sidebarActions.onControllers = [this]() { m_launcher.launchControllerPairing(); };
+    sidebarActions.onAlbum       = [this]() {
+        scheduleLeaveCapture([this]() { m_launcher.launchAlbum(); });
+    };
+    sidebarActions.onMiiEditor   = [this]() {
+        scheduleLeaveCapture([this]() { m_launcher.launchMiiEditor(); });
+    };
+    sidebarActions.onControllers = [this]() {
+        scheduleLeaveCapture([this]() { m_launcher.launchControllerPairing(); });
+    };
 #else
     sidebarActions.onAlbum       = [this]() { m_audio.playSfx(Sfx::Activate); };
     sidebarActions.onMiiEditor   = [this]() { m_audio.playSfx(Sfx::Activate); };
@@ -3918,6 +4010,9 @@ void WiiUMenuApp::finalizeRefresh() {
 #endif
 
 void WiiUMenuApp::onUpdate(float dt) {
+    updateLeaveSplashHandoff(dt);
+    const float motionDt = m_leaveMotionFrozen ? 0.f : dt;
+
     // Widget-owned images are intentionally managed before recording the next
     // frame. This is the only safe point to retire Deko textures from pages
     // that have left the screen and to warm the next page.
@@ -4239,7 +4334,7 @@ void WiiUMenuApp::onUpdate(float dt) {
 
     if (m_pendingNetConnect) {
         m_pendingNetConnect = false;
-        m_launcher.launchNetConnect();
+        scheduleLeaveCapture([this]() { m_launcher.launchNetConnect(); });
         return;
     }
 
@@ -4540,7 +4635,7 @@ void WiiUMenuApp::onUpdate(float dt) {
         }
     }
 
-    nxui::AnimationManager::instance().update(dt);
+    nxui::AnimationManager::instance().update(motionDt);
 
     // In dynamic-line mode the focused widget itself is moving. Sample its
     // interpolated display rectangle every frame so the focus ring remains
@@ -5110,6 +5205,13 @@ void WiiUMenuApp::onRender(nxui::Renderer& ren) {
             armTicksToNs(armGetSystemTick() - m_fastReturnStartupTick) / 1'000'000ULL);
         DebugLog::log("[first-frame] fast HOME return rendered in %lums", elapsedMs);
         m_fastReturnStartupTick = 0;
+    }
+    if (leaveSplashActive() && m_leaveSplashTex.valid()) {
+        const float alpha = (m_leaveSplashPhase == LeaveSplashPhase::Hold)
+            ? 1.f
+            : m_leaveSplashFade;
+        ren.drawTexture(&m_leaveSplashTex, {0.f, 0.f, 1280.f, 720.f},
+                        nxui::Color::white().withAlpha(alpha));
     }
     if (m_returnFadeTimer > 0.f) {
         float alpha = m_returnFadeTimer / kReturnFadeInDur;

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -341,9 +341,16 @@ bool WiiUMenuApp::presentInitialFrame(nxui::Renderer& ren) {
 #endif
 }
 
-void WiiUMenuApp::scheduleLeaveCapture(std::function<void()> afterCapture) {
+void WiiUMenuApp::scheduleLeaveCapture(std::function<void()> afterCapture,
+                                       std::uint64_t previewSuspendedTitleId) {
     // Only title launch/resume should call this. System applets leave the last
     // title snapshot in place so AppletReturn keeps a matching splash+session.
+    //
+    // Preview the launching title as suspended before this frame renders so the
+    // captured splash matches HOME after return (pulse on the new open title).
+    if (previewSuspendedTitleId != 0)
+        setSuspendedIconVisuals(previewSuspendedTitleId);
+
     if (m_leaveCapturePending) {
         if (!afterCapture)
             return;
@@ -361,6 +368,13 @@ void WiiUMenuApp::scheduleLeaveCapture(std::function<void()> afterCapture) {
     }
     m_leaveCapturePending = true;
     m_leaveCaptureAfter = std::move(afterCapture);
+}
+
+void WiiUMenuApp::setSuspendedIconVisuals(std::uint64_t titleId) {
+    if (!m_grid)
+        return;
+    for (auto& icon : m_grid->allIcons())
+        icon->setSuspended(titleId != 0 && icon->titleId() == titleId);
 }
 
 LeaveFrameSession WiiUMenuApp::captureLeaveSession() const {
@@ -2992,7 +3006,7 @@ void WiiUMenuApp::activateApplication(GlossyIcon* source, AppEntry* entry,
                     m_widgetStore.save();
                     m_launcher.resumeApplication();
                 });
-        });
+        }, titleId);
         return;
     }
 
@@ -3034,7 +3048,7 @@ void WiiUMenuApp::activateApplication(GlossyIcon* source, AppEntry* entry,
                     m_widgetStore.save();
                     m_launcher.launchApplication(id, selectedUid);
                 });
-        });
+        }, titleId);
     };
 
     if (entry) {

--- a/projects/menu/src/core/WiiUMenuApp.cpp
+++ b/projects/menu/src/core/WiiUMenuApp.cpp
@@ -342,6 +342,8 @@ bool WiiUMenuApp::presentInitialFrame(nxui::Renderer& ren) {
 }
 
 void WiiUMenuApp::scheduleLeaveCapture(std::function<void()> afterCapture) {
+    // Only title launch/resume should call this. System applets leave the last
+    // title snapshot in place so AppletReturn keeps a matching splash+session.
     if (m_leaveCapturePending) {
         if (!afterCapture)
             return;
@@ -827,7 +829,7 @@ void WiiUMenuApp::appendAddUserButton() {
     add->setOnActivate([this]() {
         m_audio.playSfx(Sfx::Activate);
 #ifdef SWITCHU_MENU
-        scheduleLeaveCapture([this]() { m_launcher.launchUserCreator(); });
+        m_launcher.launchUserCreator();
 #endif
     });
     m_userAvatarButtons.push_back(add);
@@ -924,7 +926,7 @@ void WiiUMenuApp::loadNextUserAvatar() {
     avatar->setOnActivate([this, uid]() {
         m_audio.playSfx(Sfx::Activate);
 #ifdef SWITCHU_MENU
-        scheduleLeaveCapture([this, uid]() { m_launcher.launchUserPage(uid); });
+        m_launcher.launchUserPage(uid);
 #endif
     });
 
@@ -3444,11 +3446,13 @@ void WiiUMenuApp::buildGrid() {
         updateCursor();
     });
 
-    // Prefer the leave-frame session (page/folder/focus) when returning from a
-    // title or applet so the live UI matches the splash we just showed.
+    // Prefer the leave-frame session from the last title launch/resume so the
+    // live UI matches the splash. System applets do not rewrite that cache.
+    bool restoredLeaveSession = false;
 #ifdef SWITCHU_MENU
     if (m_leaveSession.valid) {
         restoreLeaveSession();
+        restoredLeaveSession = true;
     } else if (m_launcher.suspendedTitleId() != 0) {
         int initialPage = 0;
         int suspendedIndex = findTitleIndex(m_launcher.suspendedTitleId());
@@ -3495,15 +3499,9 @@ void WiiUMenuApp::buildGrid() {
 
     SidebarManager::Actions sidebarActions;
 #ifdef SWITCHU_MENU
-    sidebarActions.onAlbum       = [this]() {
-        scheduleLeaveCapture([this]() { m_launcher.launchAlbum(); });
-    };
-    sidebarActions.onMiiEditor   = [this]() {
-        scheduleLeaveCapture([this]() { m_launcher.launchMiiEditor(); });
-    };
-    sidebarActions.onControllers = [this]() {
-        scheduleLeaveCapture([this]() { m_launcher.launchControllerPairing(); });
-    };
+    sidebarActions.onAlbum       = [this]() { m_launcher.launchAlbum(); };
+    sidebarActions.onMiiEditor   = [this]() { m_launcher.launchMiiEditor(); };
+    sidebarActions.onControllers = [this]() { m_launcher.launchControllerPairing(); };
 #else
     sidebarActions.onAlbum       = [this]() { m_audio.playSfx(Sfx::Activate); };
     sidebarActions.onMiiEditor   = [this]() { m_audio.playSfx(Sfx::Activate); };
@@ -3699,10 +3697,23 @@ void WiiUMenuApp::buildGrid() {
     root.addChild(m_contentLayer);
     root.addChild(m_overlayLayer);
 
-    if (!focusTitle(m_launcher.suspendedTitleId())) {
+#ifdef SWITCHU_MENU
+    // Leave-session restore already placed page/folder/focus to match the
+    // title splash. Calling focusTitle(suspended) afterward would reopen a
+    // folder under a mismatched root splash when returning from applets.
+    if (!restoredLeaveSession) {
+        if (!focusTitle(m_launcher.suspendedTitleId())) {
+            if (auto* firstIcon = m_grid->focusManager().current())
+                focusManager().setFocus(firstIcon);
+        }
+    } else if (!focusManager().current()) {
         if (auto* firstIcon = m_grid->focusManager().current())
             focusManager().setFocus(firstIcon);
     }
+#else
+    if (auto* firstIcon = m_grid->focusManager().current())
+        focusManager().setFocus(firstIcon);
+#endif
     updateCursor();
     showFocusedSteamGridDbArtwork();
     m_themeRenderDebugFrames = 12;
@@ -4334,7 +4345,7 @@ void WiiUMenuApp::onUpdate(float dt) {
 
     if (m_pendingNetConnect) {
         m_pendingNetConnect = false;
-        scheduleLeaveCapture([this]() { m_launcher.launchNetConnect(); });
+        m_launcher.launchNetConnect();
         return;
     }
 

--- a/projects/menu/src/core/WiiUMenuApp.hpp
+++ b/projects/menu/src/core/WiiUMenuApp.hpp
@@ -35,6 +35,7 @@
 #include "core/FolderStore.hpp"
 #include "core/WidgetStore.hpp"
 #include "core/ThemePreset.hpp"
+#include "core/LeaveFrameCache.hpp"
 #include "sidebar/SidebarManager.hpp"
 #include "launcher/AppletLauncher.hpp"
 #include "launcher/AppListLoader.hpp"
@@ -56,6 +57,7 @@
 #include <atomic>
 #include <future>
 #include <utility>
+#include <functional>
 #include <unordered_map>
 #include <switch.h>
 #ifdef SWITCHU_MENU
@@ -84,6 +86,8 @@ public:
     void onDestroy() override;
     void onUpdate(float dt) override;
     void onRender(nxui::Renderer& ren) override;
+    bool presentInitialFrame(nxui::Renderer& ren) override;
+    void onAfterPresent(nxui::Renderer& ren) override;
 
     nxui::Widget* focusRoot() override;
 
@@ -156,6 +160,13 @@ private:
                              std::uint64_t titleId,
                              const std::string& launchTitle);
 #endif
+    void scheduleLeaveCapture(std::function<void()> afterCapture);
+    LeaveFrameSession captureLeaveSession() const;
+    bool saveLeaveFrame(nxui::Renderer& ren);
+    void restoreLeaveSession();
+    void setLeaveMotionFrozen(bool frozen);
+    void updateLeaveSplashHandoff(float dt);
+    bool leaveSplashActive() const;
     void renameFolder(std::uint32_t folderId);
     void showFolderContextMenu(std::uint32_t folderId);
     bool saveFoldersOrReport(const char* operation);
@@ -505,6 +516,20 @@ private:
     std::future<void> m_accessibilityFuture;
     bool m_accessibilityReady = false;
     std::uint64_t m_fastReturnStartupTick = 0;
+
+    bool m_leaveCapturePending = false;
+    std::function<void()> m_leaveCaptureAfter;
+    LeaveFrameSession m_leaveSession;
+    nxui::Texture m_leaveSplashTex;
+    enum class LeaveSplashPhase { None, Hold, Fade };
+    LeaveSplashPhase m_leaveSplashPhase = LeaveSplashPhase::None;
+    float m_leaveSplashHoldRemaining = 0.f;
+    float m_leaveSplashFade = 0.f;
+    bool m_leaveSplashDrawn = false;
+    bool m_leaveMotionFrozen = false;
+    bool m_leaveMotionFreezePending = false;
+    static constexpr float kLeaveSplashHoldDur = 0.14f;
+    static constexpr float kLeaveSplashFadeDur = 0.42f;
 
     bool  m_audioInitPending = false;
     bool  m_audioHeldLogged  = false;

--- a/projects/menu/src/core/WiiUMenuApp.hpp
+++ b/projects/menu/src/core/WiiUMenuApp.hpp
@@ -160,7 +160,10 @@ private:
                              std::uint64_t titleId,
                              const std::string& launchTitle);
 #endif
-    void scheduleLeaveCapture(std::function<void()> afterCapture);
+    void scheduleLeaveCapture(std::function<void()> afterCapture,
+                              std::uint64_t previewSuspendedTitleId = 0);
+    /// Visual-only suspended outline for leave-frame capture (no focus move).
+    void setSuspendedIconVisuals(std::uint64_t titleId);
     LeaveFrameSession captureLeaveSession() const;
     bool saveLeaveFrame(nxui::Renderer& ren);
     void restoreLeaveSession();

--- a/projects/menu/src/core/WiiUMenuApp.hpp
+++ b/projects/menu/src/core/WiiUMenuApp.hpp
@@ -528,8 +528,8 @@ private:
     bool m_leaveSplashDrawn = false;
     bool m_leaveMotionFrozen = false;
     bool m_leaveMotionFreezePending = false;
-    static constexpr float kLeaveSplashHoldDur = 0.14f;
-    static constexpr float kLeaveSplashFadeDur = 0.42f;
+    static constexpr float kLeaveSplashHoldDur = 0.06f;
+    static constexpr float kLeaveSplashFadeDur = 0.25f;
 
     bool  m_audioInitPending = false;
     bool  m_audioHeldLogged  = false;

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -915,20 +915,13 @@ bool WiiUMenuApp::focusTitle(uint64_t titleId) {
 }
 
 void WiiUMenuApp::markSuspendedIcon(uint64_t titleId) {
-    if (!m_grid)
-        return;
-    for (auto& icon : m_grid->allIcons())
-        icon->setSuspended(titleId != 0 && icon->titleId() == titleId);
+    setSuspendedIconVisuals(titleId);
     if (titleId != 0)
         focusTitle(titleId);
 
-    if (auto* cur = m_grid->focusManager().current()) {
+    if (auto* cur = m_grid ? m_grid->focusManager().current() : nullptr) {
         auto* icon = static_cast<GlossyIcon*>(cur);
-        if (m_launcher.isAppSuspended(icon->titleId())) {
-            m_titlePill->setText(icon->title());
-        } else {
-            m_titlePill->setText(icon->title());
-        }
+        m_titlePill->setText(icon->title());
     }
 }
 

--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -961,6 +961,8 @@ void WiiUMenuApp::closeActiveOverlays() {
 }
 
 nxui::Widget* WiiUMenuApp::focusRoot() {
+    if (m_leaveCapturePending) return nullptr;
+    if (leaveSplashActive()) return nullptr;
     if (m_launchAnim && m_launchAnim->isPlaying()) return nullptr;
     if (m_folderCaptureRequested) return nullptr;
     if (m_progressDialog && m_progressDialog->isActive()) return m_progressDialog.get();

--- a/projects/menu/src/core/WiiUMenuAppSettings.cpp
+++ b/projects/menu/src/core/WiiUMenuAppSettings.cpp
@@ -409,11 +409,11 @@ void WiiUMenuApp::createSettings() {
     });
     m_settings->onControllerPairing([this]() {
         if (m_settings) m_settings->hide();
-        m_launcher.launchControllerPairing();
+        scheduleLeaveCapture([this]() { m_launcher.launchControllerPairing(); });
     });
     m_settings->onControllerRemapping([this]() {
         if (m_settings) m_settings->hide();
-        m_launcher.launchControllerRemapping();
+        scheduleLeaveCapture([this]() { m_launcher.launchControllerRemapping(); });
     });
     m_settings->onControllerTest([this]() {
         if (!m_controllerTest) return;

--- a/projects/menu/src/core/WiiUMenuAppSettings.cpp
+++ b/projects/menu/src/core/WiiUMenuAppSettings.cpp
@@ -409,11 +409,11 @@ void WiiUMenuApp::createSettings() {
     });
     m_settings->onControllerPairing([this]() {
         if (m_settings) m_settings->hide();
-        scheduleLeaveCapture([this]() { m_launcher.launchControllerPairing(); });
+        m_launcher.launchControllerPairing();
     });
     m_settings->onControllerRemapping([this]() {
         if (m_settings) m_settings->hide();
-        scheduleLeaveCapture([this]() { m_launcher.launchControllerRemapping(); });
+        m_launcher.launchControllerRemapping();
     });
     m_settings->onControllerTest([this]() {
         if (!m_controllerTest) return;

--- a/projects/menu/src/widgets/GlossyIcon.cpp
+++ b/projects/menu/src/widgets/GlossyIcon.cpp
@@ -534,8 +534,9 @@ void GlossyIcon::onContentUpdate(float dt) {
             m_appearOpacity.set(1.f, 0.3f, nxui::Easing::outExpo);
         }
     }
-    m_suspendPulse += dt * 2.2f;
-    if (m_entryKind == GridEntryKind::Widget && m_widgetAnimation.hasFrames())
+    if (!m_motionPaused)
+        m_suspendPulse += dt * 2.2f;
+    if (!m_motionPaused && m_entryKind == GridEntryKind::Widget && m_widgetAnimation.hasFrames())
         m_widgetAnimation.update(dt, true);
 #ifdef SWITCHU_MENU
     if (m_entryKind == GridEntryKind::Widget &&

--- a/projects/menu/src/widgets/GlossyIcon.hpp
+++ b/projects/menu/src/widgets/GlossyIcon.hpp
@@ -34,6 +34,8 @@ public:
 
     void setSuspended(bool s)     { m_suspended = s; }
     bool isSuspended() const      { return m_suspended; }
+    void setMotionPaused(bool paused) { m_motionPaused = paused; }
+    bool motionPaused() const { return m_motionPaused; }
 
     void setIsGameCard(bool gc)     { m_isGameCard = gc; }
     bool isGameCard() const         { return m_isGameCard; }
@@ -123,6 +125,7 @@ private:
     bool        m_focused = false;
     bool        m_focusable = true;
     bool        m_suspended = false;
+    bool        m_motionPaused = false;
     bool        m_isGameCard = false;
     bool        m_notLaunchable = false;
     nxui::Color m_loadingColor = nxui::Color::white();

--- a/projects/menu/src/widgets/SelectionCursor.cpp
+++ b/projects/menu/src/widgets/SelectionCursor.cpp
@@ -107,6 +107,8 @@ nxui::Rect SelectionCursor::currentRect() const {
 }
 
 void SelectionCursor::onUpdate(float dt) {
+    if (m_motionPaused)
+        return;
     m_time += dt;
 }
 

--- a/projects/menu/src/widgets/SelectionCursor.hpp
+++ b/projects/menu/src/widgets/SelectionCursor.hpp
@@ -13,6 +13,8 @@ public:
     void setColor(const nxui::Color& c) { m_color = c; }
     void setCornerRadius(float r)  { m_cornerRadius.setImmediate(r); }
     void setBorderWidth(float w)   { m_borderWidth = w; }
+    void setMotionPaused(bool paused) { m_motionPaused = paused; }
+    bool motionPaused() const { return m_motionPaused; }
 
 protected:
     void onUpdate(float dt) override;
@@ -28,5 +30,6 @@ private:
     float m_time = 0.f;
     float m_waveSpeed = 3.5f;
     bool  m_initialized = false;
+    bool  m_motionPaused = false;
 };
 

--- a/projects/menu/src/widgets/WaraWaraBackground.cpp
+++ b/projects/menu/src/widgets/WaraWaraBackground.cpp
@@ -231,6 +231,8 @@ void WaraWaraBackground::regenerate(int count) {
 }
 
 void WaraWaraBackground::onUpdate(float dt) {
+    if (m_motionPaused)
+        return;
     m_time += dt;
     for (auto& s : m_shapes) {
         if (m_config.layout == Layout::Floating) {

--- a/projects/menu/src/widgets/WaraWaraBackground.hpp
+++ b/projects/menu/src/widgets/WaraWaraBackground.hpp
@@ -61,6 +61,9 @@ public:
     bool loadImage(nxui::GpuDevice& gpu, nxui::Renderer& ren, const std::string& path);
     void clearImage();
 
+    void setMotionPaused(bool paused) { m_motionPaused = paused; }
+    bool motionPaused() const { return m_motionPaused; }
+
     void regenerate(int count = 50) override;
 
 protected:
@@ -93,5 +96,6 @@ private:
     std::vector<Shape> m_shapes;
     nxui::Texture m_backgroundImage;
     float m_time = 0.f;
+    bool m_motionPaused = false;
 };
 


### PR DESCRIPTION
## Summary
- Cache a crisp fullscreen HOME snapshot when leaving for a title or system applet.
- On AppletReturn, show that frame immediately (instead of a blank wait) while the menu rebuilds.
- Restore page/folder/focus to match the splash, then hold briefly and crossfade with background/cursor/pulse motion frozen so the handoff feels seamless.

## Test plan
- [x] Launch a game from HOME, press HOME back — splash appears instantly and dissolves into the live menu
- [x] Resume a suspended title, return again — splash + focus land on the suspended game
- [x] Open Controllers/Album and return — same instant restore path
- [x] Cold boot / first leave after install — solid fallback (no cache yet), then cache is written on leave
- [x] Confirm input stays blocked until the splash fade completes