### PR TITLE
fix: close open folders with an outside touch

### DIFF
--- a/projects/menu/src/core/WiiUMenuAppInteraction.cpp
+++ b/projects/menu/src/core/WiiUMenuAppInteraction.cpp
@@ -1450,8 +1450,17 @@ void WiiUMenuApp::handleTouch() {
 
         float dx = input.touchDeltaX();
         float dy = input.touchDeltaY();
-        if (std::abs(dx) > kSwipeThreshold && std::abs(dx) > std::abs(dy) * 1.5f)
+        if (std::abs(dx) > kSwipeThreshold && std::abs(dx) > std::abs(dy) * 1.5f) {
             flipPage(dx < 0 ? 1 : -1);
+        } else if (m_openFolderId != 0
+                   && m_touchHitIndex < 0
+                   && std::abs(dx) < 20.f && std::abs(dy) < 20.f
+                   && m_grid
+                   && m_grid->hitTest(input.touchX(), input.touchY()) < 0) {
+            // Tap anywhere that isn't an icon (dimmed margins left/right/above/below,
+            // and empty gaps) to leave — mirrors B, including edit-mode keep-move.
+            closeFolder(m_editMode);
+        }
         m_touchHitIndex = -1;
         m_touchEditDragActive = false;
     }


### PR DESCRIPTION
## Summary
- Folders could only be left with **B**; touch had no exit path
- Tapping empty space that is not an icon (dimmed margins left/right/above/below, and gaps) now closes the folder
- Matches controller behavior in edit mode too (`closeFolder(true)` keeps the move)

## Test plan
- [x] Open a folder, tap above/below/left/right of the icons → folder closes
- [x] Tap an icon → still focuses/launches as before
- [x] Swipe to change pages inside a folder → still pages (does not close)
- [x] Enter edit/move mode inside a folder, tap outside icons → leave folder but keep move
- [x] Controller **B** still closes folders as before